### PR TITLE
feat(spendingmodel): implement full functionality for SpendingModel management

### DIFF
--- a/MoneyEz.API/Controllers/SpendingModelsController.cs
+++ b/MoneyEz.API/Controllers/SpendingModelsController.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MoneyEz.Repositories.Commons;
+using MoneyEz.Services.BusinessModels.SpendingModelModels;
+using MoneyEz.Services.Services.Interfaces;
+
+namespace MoneyEz.API.Controllers
+{
+    [Route("api/v1/spendingmodels")]
+    [ApiController]
+    public class SpendingModelsController : BaseController
+    {
+        private readonly ISpendingModelService _spendingModelService;
+
+        public SpendingModelsController(ISpendingModelService spendingModelService)
+        {
+            _spendingModelService = spendingModelService;
+        }
+
+        [HttpGet]
+        public Task<IActionResult> GetSpendingModels([FromQuery] PaginationParameter paginationParameter)
+        {
+            return ValidateAndExecute(() => _spendingModelService.GetSpendingModelsPaginationAsync(paginationParameter));
+        }
+
+        [HttpGet("{id}")]
+        public Task<IActionResult> GetSpendingModelById(Guid id)
+        {
+            return ValidateAndExecute(() => _spendingModelService.GetSpendingModelByIdAsync(id));
+        }
+
+        [HttpPost]
+        public Task<IActionResult> AddSpendingModel([FromBody] List<CreateSpendingModelModel> models)
+        {
+            return ValidateAndExecute(() => _spendingModelService.AddSpendingModelsAsync(models));
+        }
+
+        [HttpPut("{id}")]
+        public Task<IActionResult> UpdateSpendingModel(Guid id, [FromBody] UpdateSpendingModelModel model)
+        {
+            return ValidateAndExecute(() => _spendingModelService.UpdateSpendingModelAsync(id, model));
+        }
+
+        [HttpDelete("{id}")]
+        public Task<IActionResult> DeleteSpendingModel(Guid id)
+        {
+            return ValidateAndExecute(() => _spendingModelService.DeleteSpendingModelAsync(id));
+        }
+
+        [HttpPost("{id}/categories")]
+        public Task<IActionResult> AddCategoriesToSpendingModel(Guid id, [FromBody] AddCategoriesToSpendingModelModel model)
+        {
+            return ValidateAndExecute(() => _spendingModelService.AddCategoriesToSpendingModelAsync(id, model));
+        }
+
+        [HttpPut("{id}/categories")]
+        public Task<IActionResult> UpdateCategoryPercentage(Guid id, [FromBody] UpdateCategoryPercentageModel model)
+        {
+            return ValidateAndExecute(() => _spendingModelService.UpdateCategoryPercentageAsync(id, model));
+        }
+
+        [HttpDelete("{id}/categories")]
+        public Task<IActionResult> RemoveCategoriesFromSpendingModel(Guid id, [FromBody] List<Guid> categoryIds)
+        {
+            return ValidateAndExecute(() => _spendingModelService.RemoveCategoriesFromSpendingModelAsync(id, categoryIds));
+        }
+    }
+}

--- a/MoneyEz.API/DependencyInjection.cs
+++ b/MoneyEz.API/DependencyInjection.cs
@@ -170,8 +170,8 @@ namespace MoneyEz.API
 
             services.AddDbContext<MoneyEzContext>(options =>
             {
-                options.UseSqlServer(config.GetConnectionString("MoneyEzLocal"));
-                //options.UseSqlServer(config.GetConnectionString("MoneyEzDbVps"));
+                //options.UseSqlServer(config.GetConnectionString("MoneyEzLocal"));
+                options.UseSqlServer(config.GetConnectionString("MoneyEzDbVps"));
             });
 
             #endregion

--- a/MoneyEz.API/DependencyInjection.cs
+++ b/MoneyEz.API/DependencyInjection.cs
@@ -143,7 +143,14 @@ namespace MoneyEz.API
             services.AddScoped<IUserRepository, UserRepository>();
             services.AddScoped<IUserService, UserService>();
 
-            // Đăng ký Service và Repository cho Category
+            //config spending model service
+            services.AddScoped<ISpendingModelService, SpendingModelService>();
+            services.AddScoped<ISpendingModelRepository, SpendingModelRepository>();
+
+            //config spending model category service
+            services.AddScoped<ISpendingModelCategoryRepository, SpendingModelCategoryRepository>();
+
+            // config category service
             services.AddScoped<ICategoryService, CategoryService>();
             services.AddScoped<ICategoriesRepository, CategoriesRepository>();
 
@@ -163,8 +170,8 @@ namespace MoneyEz.API
 
             services.AddDbContext<MoneyEzContext>(options =>
             {
-                //options.UseSqlServer(config.GetConnectionString("MoneyEzLocal"));
-                options.UseSqlServer(config.GetConnectionString("MoneyEzDbVps"));
+                options.UseSqlServer(config.GetConnectionString("MoneyEzLocal"));
+                //options.UseSqlServer(config.GetConnectionString("MoneyEzDbVps"));
             });
 
             #endregion

--- a/MoneyEz.API/appsettings.json
+++ b/MoneyEz.API/appsettings.json
@@ -21,7 +21,7 @@
     "Port": 587
   },
   "ConnectionStrings": {
-    "MoneyEzLocal": "Server=(local);Uid=sa;Pwd=123456789;Database=MoneyEz;TrustServerCertificate=True",
+    "MoneyEzLocal": "Server=(local);Uid=sa;Pwd=12345;Database=MoneyEz;TrustServerCertificate=True",
     "MoneyEzDbVps": "Data Source=178.128.118.171,1433;Initial Catalog=MoneyEz;Persist Security Info=True;User ID=sa;Password=Abc@12345;TrustServerCertificate=True"
   },
   "RedisSettings": {

--- a/MoneyEz.API/appsettings.json
+++ b/MoneyEz.API/appsettings.json
@@ -21,7 +21,7 @@
     "Port": 587
   },
   "ConnectionStrings": {
-    "MoneyEzLocal": "Server=(local);Uid=sa;Pwd=12345;Database=MoneyEz;TrustServerCertificate=True",
+    "MoneyEzLocal": "Server=(local);Uid=sa;Pwd=123456789;Database=MoneyEz;TrustServerCertificate=True",
     "MoneyEzDbVps": "Data Source=178.128.118.171,1433;Initial Catalog=MoneyEz;Persist Security Info=True;User ID=sa;Password=Abc@12345;TrustServerCertificate=True"
   },
   "RedisSettings": {

--- a/MoneyEz.Repositories/Repositories/Implements/SpendingModelCategoryRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Implements/SpendingModelCategoryRepository.cs
@@ -1,0 +1,12 @@
+﻿using MoneyEz.Repositories.Entities;
+using MoneyEz.Repositories.Repositories.Interfaces;
+
+namespace MoneyEz.Repositories.Repositories.Implements
+{
+    public class SpendingModelCategoryRepository : GenericRepository<SpendingModelCategory>, ISpendingModelCategoryRepository
+    {
+        public SpendingModelCategoryRepository(MoneyEzContext context) : base(context)
+        {
+        }
+    }
+}

--- a/MoneyEz.Repositories/Repositories/Implements/SpendingModelRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Implements/SpendingModelRepository.cs
@@ -1,0 +1,10 @@
+﻿using MoneyEz.Repositories.Entities;
+using MoneyEz.Repositories.Repositories.Interfaces;
+
+namespace MoneyEz.Repositories.Repositories.Implements
+{
+    public class SpendingModelRepository : GenericRepository<SpendingModel>, ISpendingModelRepository
+    {
+        public SpendingModelRepository(MoneyEzContext context) : base(context) { }
+    }
+}

--- a/MoneyEz.Repositories/Repositories/Interfaces/ISpendingModelCategoryRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Interfaces/ISpendingModelCategoryRepository.cs
@@ -1,0 +1,8 @@
+﻿using MoneyEz.Repositories.Entities;
+
+namespace MoneyEz.Repositories.Repositories.Interfaces
+{
+    public interface ISpendingModelCategoryRepository : IGenericRepository<SpendingModelCategory>
+    {
+    }
+}

--- a/MoneyEz.Repositories/Repositories/Interfaces/ISpendingModelRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Interfaces/ISpendingModelRepository.cs
@@ -1,0 +1,8 @@
+﻿using MoneyEz.Repositories.Entities;
+
+namespace MoneyEz.Repositories.Repositories.Interfaces
+{
+    public interface ISpendingModelRepository : IGenericRepository<SpendingModel>
+    {
+    }
+}

--- a/MoneyEz.Repositories/UnitOfWork/IUnitOfWork.cs
+++ b/MoneyEz.Repositories/UnitOfWork/IUnitOfWork.cs
@@ -12,6 +12,13 @@ namespace MoneyEz.Repositories.UnitOfWork
         // add interface repository here
 
         IUserRepository UsersRepository { get; }
+
+        //spending model
+        ISpendingModelRepository SpendingModelRepository { get; }
+
+        //spending model category
+        ISpendingModelCategoryRepository SpendingModelCategoryRepository { get; }
+
         //category
         ICategoriesRepository CategoriesRepository { get; }
 

--- a/MoneyEz.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/MoneyEz.Repositories/UnitOfWork/UnitOfWork.cs
@@ -17,9 +17,16 @@ namespace MoneyEz.Repositories.UnitOfWork
         private IDbContextTransaction _transaction;
 
         private IUserRepository _userRepository;
+
+        //spending model
+        private ISpendingModelRepository _spendingModelRepository;
+
+        //spending model category
+        private ISpendingModelCategoryRepository _spendingModelCategoryRepository;
+
         //category  
         private ICategoriesRepository _categoriesRepository;
-
+        
         public UnitOfWork(MoneyEzContext context) 
         { 
             _context = context;
@@ -31,6 +38,22 @@ namespace MoneyEz.Repositories.UnitOfWork
             {
                 return _userRepository ??= new UserRepository(_context);
 
+            }
+        }
+
+        public ISpendingModelRepository SpendingModelRepository
+        {
+            get
+            {
+                return _spendingModelRepository ??= new SpendingModelRepository(_context);
+            }
+        }
+
+        public ISpendingModelCategoryRepository SpendingModelCategoryRepository
+        {
+            get
+            {
+                return _spendingModelCategoryRepository ??= new SpendingModelCategoryRepository(_context);
             }
         }
 

--- a/MoneyEz.Services/BusinessModels/SpendingModelModels/AddCategoriesToSpendingModelModel.cs
+++ b/MoneyEz.Services/BusinessModels/SpendingModelModels/AddCategoriesToSpendingModelModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.SpendingModelModels
+{
+    public class AddCategoriesToSpendingModelModel
+    {
+
+        [Required(ErrorMessage = "The list of category IDs cannot be empty.")]
+        public List<Guid> CategoryIds { get; set; } // Danh sách các CategoryId cần thêm
+
+        public List<decimal>? PercentageAmounts { get; set; } // Tùy chọn danh sách PercentageAmount (phải khớp số lượng với CategoryIds nếu có)
+
+        public AddCategoriesToSpendingModelModel()
+        {
+            CategoryIds = new List<Guid>();
+        }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/SpendingModelModels/CreateSpendingModelModel.cs
+++ b/MoneyEz.Services/BusinessModels/SpendingModelModels/CreateSpendingModelModel.cs
@@ -1,0 +1,21 @@
+﻿using MoneyEz.Services.Utils;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.SpendingModelModels
+{
+    public class CreateSpendingModelModel
+    {
+        [Required(ErrorMessage = "Tên mô hình là bắt buộc.")]
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+
+        public bool? IsTemplate { get; set; } = false; // Giá trị mặc định là false
+
+        public string NameUnsign => StringUtils.ConvertToUnSign(Name);
+
+    }
+}
+

--- a/MoneyEz.Services/BusinessModels/SpendingModelModels/SpendingModelCategoryModel.cs
+++ b/MoneyEz.Services/BusinessModels/SpendingModelModels/SpendingModelCategoryModel.cs
@@ -1,0 +1,10 @@
+﻿using MoneyEz.Services.BusinessModels.CategoryModels;
+
+namespace MoneyEz.Services.BusinessModels.SpendingModelModels
+{
+    public class SpendingModelCategoryModel
+    {
+        public decimal PercentageAmount { get; set; } // Phần trăm phân bổ
+        public CategoryModel Category { get; set; } // Thông tin chi tiết của Category
+    }
+}

--- a/MoneyEz.Services/BusinessModels/SpendingModelModels/SpendingModelModel.cs
+++ b/MoneyEz.Services/BusinessModels/SpendingModelModels/SpendingModelModel.cs
@@ -1,0 +1,16 @@
+﻿using MoneyEz.Repositories.Entities;
+using MoneyEz.Services.BusinessModels.CategoryModels;
+using System;
+using System.Collections.Generic;
+
+namespace MoneyEz.Services.BusinessModels.SpendingModelModels
+{
+    public class SpendingModelModel : BaseEntity
+    {
+        public string Name { get; set; }
+        public string NameUnsign { get; set; }
+        public string Description { get; set; }
+        public bool? IsTemplate { get; set; }
+        public List<SpendingModelCategoryModel> Categories { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/SpendingModelModels/UpdateCategoryPercentageModel.cs
+++ b/MoneyEz.Services/BusinessModels/SpendingModelModels/UpdateCategoryPercentageModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.SpendingModelModels
+{
+    public class UpdateCategoryPercentageModel
+    {
+        [Required(ErrorMessage = "Danh sách danh mục là bắt buộc.")]
+        public List<CategoryPercentageModel> Categories { get; set; }
+    }
+
+    public class CategoryPercentageModel
+    {
+        [Required(ErrorMessage = "ID danh mục là bắt buộc.")]
+        public Guid CategoryId { get; set; }
+
+        [Range(0, 100, ErrorMessage = "Tỷ lệ phần trăm phải nằm trong khoảng từ 0 đến 100.")]
+        public decimal PercentageAmount { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/SpendingModelModels/UpdateSpendingModelModel.cs
+++ b/MoneyEz.Services/BusinessModels/SpendingModelModels/UpdateSpendingModelModel.cs
@@ -1,0 +1,18 @@
+﻿using MoneyEz.Services.Utils;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.SpendingModelModels
+{
+    public class UpdateSpendingModelModel
+    {
+        [Required(ErrorMessage = "Tên mô hình là bắt buộc.")]
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+
+        public bool? IsTemplate { get; set; }
+
+        public string NameUnsign => StringUtils.ConvertToUnSign(Name);
+    }
+}

--- a/MoneyEz.Services/Constants/MessageConstants.cs
+++ b/MoneyEz.Services/Constants/MessageConstants.cs
@@ -33,6 +33,29 @@ namespace MoneyEz.Services.Constants
         public const string ACCOUNT_EXISTED = "AccountAlreadyExisted";
         public const string ACCOUNT_BLOCKED = "AccountWasBlocked";
 
+        // Spending model
+        public const string SPENDING_MODEL_LIST_FETCHED_SUCCESS = "Spending model list fetched successfully.";
+        public const string SPENDING_MODEL_FETCHED_SUCCESS = "Spending model details fetched successfully.";
+        public const string SPENDING_MODEL_CREATED_SUCCESS = "Spending model created successfully.";
+        public const string SPENDING_MODEL_UPDATED_SUCCESS = "Spending model updated successfully.";
+        public const string SPENDING_MODEL_DELETED_SUCCESS = "Spending model deleted successfully.";
+        public const string SPENDING_MODEL_NOT_FOUND = "Spending model not found.";
+        public const string SPENDING_MODEL_ALREADY_EXISTS = "Spending model already exists.";
+        public const string SPENDING_MODEL_HAS_DEPENDENCIES = "Spending model has dependencies and cannot be deleted.";
+        public const string DUPLICATE_SPENDING_MODELS = "Duplicate spending models found in the provided list.";
+        public const string EMPTY_SPENDING_MODEL_LIST = "The spending model list is empty.";
+        public const string SPENDING_MODEL_IS_TEMPLATE_UPDATED = "Spending model template status updated successfully.";
+        public const string DUPLICATE_CATEGORY_IDS_IN_LIST = "Duplicate category IDs found in the provided list.";
+        public const string CATEGORIES_ALREADY_ADDED = "All categories in the list are already added to the spending model.";
+        public const string CATEGORY_NOT_FOUND_IN_SPENDING_MODEL = "The category was not found in the spending model.";
+        public const string CATEGORIES_NOT_FOUND_IN_SPENDING_MODEL = "None of the categories were found in the spending model.";
+        public const string DUPLICATE_CATEGORY_IDS_IN_REQUEST = "Duplicate category IDs found in the request.";
+        public const string INVALID_CATEGORY_IDS = "Some category IDs do not exist in the database.";
+        public const string EMPTY_CATEGORY_LIST = "The list of category IDs cannot be empty.";
+        public const string INVALID_TOTAL_PERCENTAGE = "The total percentage amount of all categories must be greater than 0 and less than or equal to 100.";
+        public const string PERCENTAGE_REQUIRED = "Percentage amounts must be provided for the categories.";
+        public const string PERCENTAGE_MISMATCH = "The number of percentage amounts must match the number of category IDs.";
+
         // category
         public const string CATEGORY_ALREADY_EXISTS = "CategoryAlreadyExists";
         public const string CATEGORY_CREATED_SUCCESS = "CategoryCreatedSuccessfully";

--- a/MoneyEz.Services/Mappers/CategoryMapperConfig.cs
+++ b/MoneyEz.Services/Mappers/CategoryMapperConfig.cs
@@ -8,12 +8,15 @@ namespace MoneyEz.Services.Mappers
     {
         partial void CategoryMapperConfig()
         {
+            // Map từ CreateCategoryModel -> Category
             CreateMap<CreateCategoryModel, Category>()
                 .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => src.NameUnsign));
 
+            // Map từ UpdateCategoryModel -> Category
             CreateMap<UpdateCategoryModel, Category>()
                 .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => src.NameUnsign));
 
+            // Map từ Category -> CategoryModel
             CreateMap<Category, CategoryModel>();
         }
     }

--- a/MoneyEz.Services/Mappers/MapperConfig.cs
+++ b/MoneyEz.Services/Mappers/MapperConfig.cs
@@ -16,12 +16,15 @@ namespace MoneyEz.Services.Mappers
         {
             // user mapper
             UserMapperConfig();
+            // spending model mapper
+            SpendingModelMapperConfig();
             //category mapper
             CategoryMapperConfig();
             // transaction mapper
         }
 
         partial void UserMapperConfig();
+        partial void SpendingModelMapperConfig();
         partial void CategoryMapperConfig();
     }
 

--- a/MoneyEz.Services/Mappers/SpendingModelMapperConfig.cs
+++ b/MoneyEz.Services/Mappers/SpendingModelMapperConfig.cs
@@ -1,0 +1,42 @@
+﻿using AutoMapper;
+using MoneyEz.Repositories.Entities;
+using MoneyEz.Services.BusinessModels.CategoryModels;
+using MoneyEz.Services.BusinessModels.SpendingModelModels;
+
+namespace MoneyEz.Services.Mappers
+{
+    public partial class MapperConfig
+    {
+        partial void SpendingModelMapperConfig()
+        {
+            // Map từ CreateSpendingModelModel -> SpendingModel
+            CreateMap<CreateSpendingModelModel, SpendingModel>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => src.NameUnsign))
+                .ForMember(dest => dest.IsTemplate, opt => opt.MapFrom(src => src.IsTemplate));
+
+            // Map từ UpdateSpendingModelModel -> SpendingModel
+            CreateMap<UpdateSpendingModelModel, SpendingModel>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => src.NameUnsign))
+                .ForMember(dest => dest.IsTemplate, opt => opt.MapFrom(src => src.IsTemplate));
+
+            // Map từ SpendingModel -> SpendingModelModel
+            CreateMap<SpendingModel, SpendingModelModel>()
+                .ForMember(dest => dest.Categories, opt => opt.MapFrom(src => src.SpendingModelCategories.Select(smc => new SpendingModelCategoryModel
+                {
+                    PercentageAmount = smc.PercentageAmount ?? 0, // Xử lý null bằng 0
+                    Category = new CategoryModel
+                    {
+                        Id = smc.Category.Id,
+                        Name = smc.Category.Name,
+                        NameUnsign = smc.Category.NameUnsign,
+                        Description = smc.Category.Description,
+                        IsDeleted = smc.Category.IsDeleted,
+                        CreatedDate = smc.Category.CreatedDate,
+                        UpdatedDate = smc.Category.UpdatedDate,
+                        CreatedBy = smc.Category.CreatedBy,
+                        UpdatedBy = smc.Category.UpdatedBy
+                    }
+                })));
+        }
+    }
+}

--- a/MoneyEz.Services/Services/Implements/SpendingModelService.cs
+++ b/MoneyEz.Services/Services/Implements/SpendingModelService.cs
@@ -1,0 +1,436 @@
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using MoneyEz.Repositories.UnitOfWork;
+using MoneyEz.Repositories.Entities;
+using MoneyEz.Services.BusinessModels.SpendingModelModels;
+using MoneyEz.Services.BusinessModels.ResultModels;
+using MoneyEz.Services.Constants;
+using MoneyEz.Services.Services.Interfaces;
+using MoneyEz.Repositories.Commons;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using MoneyEz.Services.BusinessModels.CategoryModels;
+
+namespace MoneyEz.Services.Services.Implements
+{
+    public class SpendingModelService : ISpendingModelService
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        public SpendingModelService(IUnitOfWork unitOfWork, IMapper mapper)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+        }
+
+        public async Task<BaseResultModel> GetSpendingModelsPaginationAsync(PaginationParameter paginationParameter)
+        {
+            // Lấy SpendingModel cùng các danh mục liên kết
+            var spendingModels = await _unitOfWork.SpendingModelRepository.ToPaginationIncludeAsync(
+                paginationParameter,
+                include: query => query.Include(sm => sm.SpendingModelCategories)
+                                       .ThenInclude(smc => smc.Category)
+            );
+
+            // Map từ SpendingModel sang SpendingModelModel
+            var result = _mapper.Map<Pagination<SpendingModelModel>>(spendingModels);
+
+            // Trả về kết quả
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = MessageConstants.SPENDING_MODEL_LIST_FETCHED_SUCCESS,
+                Data = result
+            };
+        }
+
+        // GetSpendingModelByIdAsync
+        public async Task<BaseResultModel> GetSpendingModelByIdAsync(Guid id)
+        {
+            // Lấy SpendingModel từ repository cùng các danh mục liên quan
+            var spendingModel = await _unitOfWork.SpendingModelRepository.GetByIdIncludeAsync(
+                id,
+                include: query => query.Include(sm => sm.SpendingModelCategories)
+                                       .ThenInclude(smc => smc.Category)
+            );
+
+            if (spendingModel == null || spendingModel.IsDeleted)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_NOT_FOUND
+                };
+            }
+
+            // Map từ SpendingModel sang SpendingModelModel
+            var result = _mapper.Map<SpendingModelModel>(spendingModel);
+
+            // Trả về kết quả
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = MessageConstants.SPENDING_MODEL_FETCHED_SUCCESS,
+                Data = result
+            };
+        }
+
+        public async Task<BaseResultModel> AddSpendingModelsAsync(List<CreateSpendingModelModel> models)
+        {
+            if (models == null || !models.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.EMPTY_SPENDING_MODEL_LIST,
+                    Message = "The list of spending models cannot be empty."
+                };
+            }
+
+            var allSpendingModels = await _unitOfWork.SpendingModelRepository.GetAllAsync();
+            var existingUnsignNames = allSpendingModels
+                .Where(sm => !sm.IsDeleted)
+                .Select(sm => sm.NameUnsign)
+                .ToHashSet();
+
+            var newSpendingModels = new List<SpendingModel>();
+            var duplicateNames = new List<string>();
+
+            foreach (var model in models)
+            {
+                var unsignName = model.NameUnsign; // Xử lý tự động từ model
+                if (existingUnsignNames.Contains(unsignName) || newSpendingModels.Any(sm => sm.NameUnsign == unsignName))
+                {
+                    duplicateNames.Add(model.Name);
+                    continue;
+                }
+
+                var spendingModel = _mapper.Map<SpendingModel>(model);
+                spendingModel.NameUnsign = unsignName; // Đảm bảo gán NameUnsign
+                newSpendingModels.Add(spendingModel);
+            }
+
+            if (duplicateNames.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.DUPLICATE_SPENDING_MODELS,
+                    Message = $"The following spending models already exist: {string.Join(", ", duplicateNames)}"
+                };
+            }
+
+            await _unitOfWork.SpendingModelRepository.AddRangeAsync(newSpendingModels);
+            _unitOfWork.Save();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status201Created,
+                Message = $"{newSpendingModels.Count} spending models were added successfully."
+            };
+        }
+
+        public async Task<BaseResultModel> UpdateSpendingModelAsync(Guid id, UpdateSpendingModelModel model)
+        {
+            var spendingModel = await _unitOfWork.SpendingModelRepository.GetByIdAsync(id);
+            if (spendingModel == null || spendingModel.IsDeleted)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_NOT_FOUND,
+                    Message = "The spending model does not exist or has been deleted."
+                };
+            }
+
+            var unsignName = model.NameUnsign; // Xử lý tự động từ model
+            var allSpendingModels = await _unitOfWork.SpendingModelRepository.GetAllAsync();
+            if (allSpendingModels.Any(sm => sm.NameUnsign == unsignName && sm.Id != id))
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_ALREADY_EXISTS,
+                    Message = $"A spending model with the name '{model.Name}' already exists."
+                };
+            }
+
+            _mapper.Map(model, spendingModel);
+            spendingModel.NameUnsign = unsignName; // Đảm bảo gán NameUnsign
+            _unitOfWork.SpendingModelRepository.UpdateAsync(spendingModel);
+            _unitOfWork.Save();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = MessageConstants.SPENDING_MODEL_UPDATED_SUCCESS
+            };
+        }
+
+        public async Task<BaseResultModel> DeleteSpendingModelAsync(Guid id)
+        {
+            // Lấy SpendingModel từ database
+            var spendingModel = await _unitOfWork.SpendingModelRepository.GetByIdIncludeAsync(
+                id,
+                include: query => query.Include(sm => sm.SpendingModelCategories)
+            );
+
+            if (spendingModel == null || spendingModel.IsDeleted)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_NOT_FOUND,
+                    Message = "The spending model does not exist or has been deleted."
+                };
+            }
+
+            // Kiểm tra nếu SpendingModel có các danh mục phụ thuộc
+            if (spendingModel.SpendingModelCategories.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_HAS_DEPENDENCIES,
+                    Message = "The spending model has dependent categories and cannot be deleted."
+                };
+            }
+
+            // Thực hiện xóa mềm SpendingModel
+            _unitOfWork.SpendingModelRepository.SoftDeleteAsync(spendingModel);
+            _unitOfWork.Save();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = "The spending model was successfully deleted."
+            };
+        }
+
+        public async Task<BaseResultModel> AddCategoriesToSpendingModelAsync(Guid spendingModelId, AddCategoriesToSpendingModelModel model)
+        {
+            if (model == null || model.CategoryIds == null || !model.CategoryIds.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.EMPTY_CATEGORY_LIST,
+                    Message = "The list of category IDs cannot be empty."
+                };
+            }
+
+            var duplicateCategoryIdsInRequest = model.CategoryIds
+                .GroupBy(id => id)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToList();
+
+            if (duplicateCategoryIdsInRequest.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.DUPLICATE_CATEGORY_IDS_IN_REQUEST,
+                    Message = $"The following category IDs are duplicated in the request: {string.Join(", ", duplicateCategoryIdsInRequest)}"
+                };
+            }
+
+            var spendingModel = await _unitOfWork.SpendingModelRepository.GetByIdIncludeAsync(
+                spendingModelId,
+                include: query => query.Include(sm => sm.SpendingModelCategories)
+            );
+
+            if (spendingModel == null || spendingModel.IsDeleted)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_NOT_FOUND,
+                    Message = "The spending model does not exist or has been deleted."
+                };
+            }
+
+            var existingCategories = await _unitOfWork.CategoriesRepository.GetAllAsync();
+            var validCategoryIds = existingCategories.Select(c => c.Id).ToHashSet();
+
+            var invalidCategoryIds = model.CategoryIds.Except(validCategoryIds).ToList();
+            if (invalidCategoryIds.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.INVALID_CATEGORY_IDS,
+                    Message = $"The following category IDs do not exist: {string.Join(", ", invalidCategoryIds)}"
+                };
+            }
+
+            var existingCategoryIdsInModel = spendingModel.SpendingModelCategories.Select(smc => smc.CategoryId).ToHashSet();
+            var newCategoryIds = model.CategoryIds.Where(id => !existingCategoryIdsInModel.Contains(id)).ToList();
+
+            if (!newCategoryIds.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.CATEGORIES_ALREADY_ADDED,
+                    Message = "All categories in the list are already added to the spending model."
+                };
+            }
+
+            var newCategories = new List<SpendingModelCategory>();
+            if (!spendingModel.SpendingModelCategories.Any())
+            {
+                if (model.PercentageAmounts == null || model.PercentageAmounts.Count != newCategoryIds.Count)
+                {
+                    return new BaseResultModel
+                    {
+                        Status = StatusCodes.Status400BadRequest,
+                        ErrorCode = MessageConstants.PERCENTAGE_MISMATCH,
+                        Message = "The number of percentage amounts must match the number of category IDs."
+                    };
+                }
+
+                var totalPercentage = model.PercentageAmounts.Sum();
+                if (totalPercentage != 100)
+                {
+                    return new BaseResultModel
+                    {
+                        Status = StatusCodes.Status400BadRequest,
+                        ErrorCode = MessageConstants.INVALID_TOTAL_PERCENTAGE,
+                        Message = "The total percentage amount must equal 100%."
+                    };
+                }
+
+                for (int i = 0; i < newCategoryIds.Count; i++)
+                {
+                    newCategories.Add(new SpendingModelCategory
+                    {
+                        SpendingModelId = spendingModelId,
+                        CategoryId = newCategoryIds[i],
+                        PercentageAmount = model.PercentageAmounts[i]
+                    });
+                }
+            }
+            else
+            {
+                newCategories = newCategoryIds.Select(id => new SpendingModelCategory
+                {
+                    SpendingModelId = spendingModelId,
+                    CategoryId = id,
+                    PercentageAmount = 0
+                }).ToList();
+            }
+
+            await _unitOfWork.SpendingModelCategoryRepository.AddRangeAsync(newCategories);
+            _unitOfWork.Save();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status201Created,
+                Message = $"{newCategories.Count} categories were successfully added to the spending model."
+            };
+        }
+
+        public async Task<BaseResultModel> UpdateCategoryPercentageAsync(Guid spendingModelId, UpdateCategoryPercentageModel model)
+        {
+            var spendingModel = await _unitOfWork.SpendingModelRepository.GetByIdIncludeAsync(
+                spendingModelId,
+                include: query => query.Include(sm => sm.SpendingModelCategories)
+            );
+
+            if (spendingModel == null || spendingModel.IsDeleted)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_NOT_FOUND,
+                    Message = "The spending model does not exist or has been deleted."
+                };
+            }
+
+            foreach (var categoryPercentage in model.Categories)
+            {
+                var categoryInModel = spendingModel.SpendingModelCategories
+                    .FirstOrDefault(c => c.CategoryId == categoryPercentage.CategoryId);
+
+                if (categoryInModel == null)
+                {
+                    return new BaseResultModel
+                    {
+                        Status = StatusCodes.Status400BadRequest,
+                        ErrorCode = MessageConstants.CATEGORY_NOT_FOUND_IN_SPENDING_MODEL,
+                        Message = $"Category with ID {categoryPercentage.CategoryId} not found in the spending model."
+                    };
+                }
+
+                categoryInModel.PercentageAmount = categoryPercentage.PercentageAmount;
+            }
+
+            var totalPercentageAmount = spendingModel.SpendingModelCategories.Sum(c => c.PercentageAmount);
+            if (totalPercentageAmount != 100)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.INVALID_TOTAL_PERCENTAGE,
+                    Message = "The total percentage amount for all categories in the spending model must equal 100%."
+                };
+            }
+
+            _unitOfWork.Save();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = "Category percentages were successfully updated."
+            };
+        }
+
+        public async Task<BaseResultModel> RemoveCategoriesFromSpendingModelAsync(Guid spendingModelId, List<Guid> categoryIds)
+        {
+            // Lấy SpendingModel từ database cùng với các danh mục liên quan
+            var spendingModel = await _unitOfWork.SpendingModelRepository.GetByIdIncludeAsync(
+                spendingModelId,
+                include: query => query.Include(sm => sm.SpendingModelCategories)
+            );
+
+            if (spendingModel == null || spendingModel.IsDeleted)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    ErrorCode = MessageConstants.SPENDING_MODEL_NOT_FOUND,
+                    Message = "The spending model does not exist or has been deleted."
+                };
+            }
+
+            // Lấy danh sách các danh mục hiện có trong SpendingModel
+            var categoriesToRemove = spendingModel.SpendingModelCategories
+                .Where(smc => categoryIds.Contains(smc.CategoryId.Value))
+                .ToList();
+
+            if (!categoriesToRemove.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.CATEGORIES_NOT_FOUND_IN_SPENDING_MODEL,
+                    Message = "None of the provided categories were found in the spending model."
+                };
+            }
+
+            // Xóa các danh mục khỏi SpendingModel
+            _unitOfWork.SpendingModelCategoryRepository.PermanentDeletedListAsync(categoriesToRemove);
+            _unitOfWork.Save();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = $"{categoriesToRemove.Count} categories were successfully removed from the spending model."
+            };
+        }
+
+
+    }
+}

--- a/MoneyEz.Services/Services/Interfaces/ISpendingModelService.cs
+++ b/MoneyEz.Services/Services/Interfaces/ISpendingModelService.cs
@@ -1,0 +1,18 @@
+﻿using MoneyEz.Repositories.Commons;
+using MoneyEz.Services.BusinessModels.ResultModels;
+using MoneyEz.Services.BusinessModels.SpendingModelModels;
+
+namespace MoneyEz.Services.Services.Interfaces
+{
+    public interface ISpendingModelService
+    {
+        Task<BaseResultModel> GetSpendingModelsPaginationAsync(PaginationParameter paginationParameter);
+        Task<BaseResultModel> GetSpendingModelByIdAsync(Guid id);
+        Task<BaseResultModel> AddSpendingModelsAsync(List<CreateSpendingModelModel> models);
+        Task<BaseResultModel> UpdateSpendingModelAsync(Guid id, UpdateSpendingModelModel model);
+        Task<BaseResultModel> DeleteSpendingModelAsync(Guid id);
+        Task<BaseResultModel> AddCategoriesToSpendingModelAsync(Guid spendingModelId, AddCategoriesToSpendingModelModel model);
+        Task<BaseResultModel> UpdateCategoryPercentageAsync(Guid id, UpdateCategoryPercentageModel model);
+        Task<BaseResultModel> RemoveCategoriesFromSpendingModelAsync(Guid id, List<Guid> categoryIds);
+    }
+}


### PR DESCRIPTION
- Add methods for SpendingModel CRUD operations:
  - AddSpendingModelsAsync
  - UpdateSpendingModelAsync
  - DeleteSpendingModelAsync
  - GetSpendingModelsPaginationAsync
  - GetSpendingModelByIdAsync
- Add methods for category management in SpendingModels:
  - AddCategoriesToSpendingModelAsync with PercentageAmount handling
  - UpdateCategoryPercentageAsync with strict total percentage validation
  - RemoveCategoriesFromSpendingModelAsync with dependency checks
- Improve PercentageAmount logic:
  - Default PercentageAmount = 0 for new categories if the model already contains categories.
  - Require PercentageAmount (sum = 100%) for the first set of categories.
  - Ensure total PercentageAmount validation during updates.
- Add SpendingModelCategoryModel to include both PercentageAmount and Category details.
- Enhance AutoMapper configurations:
  - Map SpendingModelCategories with detailed CategoryModel.
  - Ensure proper mapping for SpendingModel CRUD and pagination.
- Update MessageConstants:
  - Add error messages for empty lists, duplicate entries, invalid percentages, and more.
- Optimize SQL queries with Include/ThenInclude for related entities.
- Handle nullable fields (PercentageAmount) safely with default values.