### PR TITLE
fix(asset&liability): fix the id tracking issue

### DIFF
--- a/MoneyEz.Services/Services/Implements/AssetService.cs
+++ b/MoneyEz.Services/Services/Implements/AssetService.cs
@@ -146,13 +146,15 @@ namespace MoneyEz.Services.Services.Implements
         public async Task<BaseResultModel> UpdateAssetAsync(UpdateAssetModel model)
         {
             // check exist asset id
-            if (await _unitOfWork.AssetRepository.GetByIdAsync(model.Id) == null) throw new NotExistException(MessageConstants.ASSET_NOT_FOUND);
+            var asset = await _unitOfWork.AssetRepository.GetByIdAsync(model.Id);
+            if (asset == null) throw new NotExistException(MessageConstants.ASSET_NOT_FOUND);
 
             // check exist subcategory
-            if (await _unitOfWork.SubcategoryRepository.GetByIdAsync(model.SubcategoryId) == null) throw new NotExistException(MessageConstants.SUBCATEGORY_NOT_FOUND);
+            if (await _unitOfWork.SubcategoryRepository.GetByIdAsync(model.SubcategoryId) == null) 
+                throw new NotExistException(MessageConstants.SUBCATEGORY_NOT_FOUND);
 
-            var asset = _mapper.Map<Asset>(model);
-            asset.UpdatedDate = CommonUtils.GetCurrentTime();
+            _mapper.Map(model, asset);
+            asset.NameUnsign = StringUtils.ConvertToUnSign(model.Name);
 
             _unitOfWork.AssetRepository.UpdateAsync(asset);
             await _unitOfWork.SaveAsync();

--- a/MoneyEz.Services/Services/Implements/LiabilityService.cs
+++ b/MoneyEz.Services/Services/Implements/LiabilityService.cs
@@ -145,13 +145,15 @@ namespace MoneyEz.Services.Services.Implements
         public async Task<BaseResultModel> UpdateLiabilityAsync(UpdateLiabilityModel model)
         {
             // check exist liability id
-            if (await _unitOfWork.LiabilityRepository.GetByIdAsync(model.Id) == null) throw new NotExistException(MessageConstants.LIABILITY_NOT_FOUND);
+            var liability = await _unitOfWork.LiabilityRepository.GetByIdAsync(model.Id);
+            if (liability == null) throw new NotExistException(MessageConstants.LIABILITY_NOT_FOUND);
 
             // check exist subcategory
-            if (await _unitOfWork.SubcategoryRepository.GetByIdAsync(model.SubcategoryId) == null) throw new NotExistException(MessageConstants.SUBCATEGORY_NOT_FOUND);
+            if (await _unitOfWork.SubcategoryRepository.GetByIdAsync(model.SubcategoryId) == null) 
+                throw new NotExistException(MessageConstants.SUBCATEGORY_NOT_FOUND);
 
-            var liability = _mapper.Map<Liability>(model);
-            liability.UpdatedDate = CommonUtils.GetCurrentTime();
+            _mapper.Map(model, liability);
+            liability.NameUnsign = StringUtils.ConvertToUnSign(model.Name);
 
             _unitOfWork.LiabilityRepository.UpdateAsync(liability);
             await _unitOfWork.SaveAsync();


### PR DESCRIPTION
This pull request includes changes to the `AssetService` and `LiabilityService` to improve the handling of updates for assets and liabilities. The most important changes include refactoring the update methods to enhance readability and functionality.

Improvements to update methods:

* [`MoneyEz.Services/Services/Implements/AssetService.cs`](diffhunk://#diff-3c5f773564c12292aaa0d815a9b8c43730d502bb07cc695a3372ce1af1f02199L149-R157): Refactored `UpdateAssetAsync` method to store the retrieved asset in a variable before checking for null and to map the updated model to the existing asset. Additionally, added logic to convert the asset name to an unsigned string.

* [`MoneyEz.Services/Services/Implements/LiabilityService.cs`](diffhunk://#diff-77fa3c2f8d6f3d57bbaadbdf6e23f59fec6d66745d99d8a7e10000f7241d21f9L148-R156): Refactored `UpdateLiabilityAsync` method to store the retrieved liability in a variable before checking for null and to map the updated model to the existing liability. Additionally, added logic to convert the liability name to an unsigned string.