### PR TITLE
fix(database): Add column 'Code' and 'Icon' in table 'Category' and 'SubCategory'

### DIFF
--- a/MoneyEz.Repositories/Entities/Category.cs
+++ b/MoneyEz.Repositories/Entities/Category.cs
@@ -11,6 +11,10 @@ public partial class Category : BaseEntity
 
     public string? Description { get; set; }
 
+    public string? Code { get; set; }
+
+    public string? Icon { get; set; }
+
     public virtual ICollection<SpendingModelCategory> SpendingModelCategories { get; set; } = new List<SpendingModelCategory>();
 
     public virtual ICollection<CategorySubcategory> CategorySubcategories { get; set; } = new List<CategorySubcategory>();

--- a/MoneyEz.Repositories/Entities/MoneyEzContext.cs
+++ b/MoneyEz.Repositories/Entities/MoneyEzContext.cs
@@ -117,6 +117,8 @@ public partial class MoneyEzContext : DbContext
                 .IsRequired()
                 .HasMaxLength(100);
             entity.Property(e => e.NameUnsign).HasMaxLength(100);
+            entity.Property(e => e.Code).HasMaxLength(50);
+            entity.Property(e => e.Icon).HasMaxLength(50);
         });
 
         modelBuilder.Entity<ChatHistory>(entity =>
@@ -426,6 +428,8 @@ public partial class MoneyEzContext : DbContext
                 .IsRequired()
                 .HasMaxLength(50);
             entity.Property(e => e.NameUnsign).HasMaxLength(50);
+            entity.Property(e => e.Code).HasMaxLength(50);
+            entity.Property(e => e.Icon).HasMaxLength(50);
         });
 
         modelBuilder.Entity<Subscription>(entity =>

--- a/MoneyEz.Repositories/Entities/Subcategory.cs
+++ b/MoneyEz.Repositories/Entities/Subcategory.cs
@@ -11,6 +11,10 @@ public partial class Subcategory : BaseEntity
 
     public string? Description { get; set; }
 
+    public string? Code { get; set; }
+
+    public string? Icon { get; set; }
+
     public virtual ICollection<RecurringTransaction> RecurringTransactions { get; set; } = new List<RecurringTransaction>();
 
     public virtual ICollection<Transaction> Transactions { get; set; } = new List<Transaction>();

--- a/MoneyEz.Repositories/Migrations/20250225050130_AddColumnCodeAndIcon.Designer.cs
+++ b/MoneyEz.Repositories/Migrations/20250225050130_AddColumnCodeAndIcon.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MoneyEz.Repositories.Entities;
 
@@ -11,9 +12,11 @@ using MoneyEz.Repositories.Entities;
 namespace MoneyEz.Repositories.Migrations
 {
     [DbContext(typeof(MoneyEzContext))]
-    partial class MoneyEzContextModelSnapshot : ModelSnapshot
+    [Migration("20250225050130_AddColumnCodeAndIcon")]
+    partial class AddColumnCodeAndIcon
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MoneyEz.Repositories/Migrations/20250225050130_AddColumnCodeAndIcon.cs
+++ b/MoneyEz.Repositories/Migrations/20250225050130_AddColumnCodeAndIcon.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MoneyEz.Repositories.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddColumnCodeAndIcon : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_FinancialGoal_Subcategory_SubcategoryId",
+                table: "FinancialGoal");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Code",
+                table: "Subcategory",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Icon",
+                table: "Subcategory",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Code",
+                table: "Category",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Icon",
+                table: "Category",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK__Financial__Subcategory__8A4B4B5C",
+                table: "FinancialGoal",
+                column: "SubcategoryId",
+                principalTable: "Subcategory",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK__Financial__Subcategory__8A4B4B5C",
+                table: "FinancialGoal");
+
+            migrationBuilder.DropColumn(
+                name: "Code",
+                table: "Subcategory");
+
+            migrationBuilder.DropColumn(
+                name: "Icon",
+                table: "Subcategory");
+
+            migrationBuilder.DropColumn(
+                name: "Code",
+                table: "Category");
+
+            migrationBuilder.DropColumn(
+                name: "Icon",
+                table: "Category");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_FinancialGoal_Subcategory_SubcategoryId",
+                table: "FinancialGoal",
+                column: "SubcategoryId",
+                principalTable: "Subcategory",
+                principalColumn: "Id");
+        }
+    }
+}


### PR DESCRIPTION
[Issue](https://github.com/MoneyEZ-FUHCM/moneyez-api/issues/142)

This pull request introduces new properties to the `Category` and `Subcategory` entities, updates the database context and migrations accordingly, and modifies the foreign key behavior for the `FinancialGoal` entity.

### Entity Changes:
* Added `Code` and `Icon` properties to the `Category` and `Subcategory` entities in `MoneyEz.Repositories/Entities/Category.cs` and `MoneyEz.Repositories/Entities/Subcategory.cs`. [[1]](diffhunk://#diff-f3de2250849361b719f6b60db4995e5c05fa473931f241000d1f1572aa88da8aR14-R17) [[2]](diffhunk://#diff-b413f5058c060d5e50b0e26bd0f50f14b1b7fa978d12dc6f9734259495b38682R14-R17)

### Database Context Changes:
* Updated `OnModelCreating` in `MoneyEz.Repositories/Entities/MoneyEzContext.cs` to configure the new `Code` and `Icon` properties. [[1]](diffhunk://#diff-0795c5c0d12ecbc3a9bd459f69780294fd60fb2145c858d55a357b193ece6baeR120-R121) [[2]](diffhunk://#diff-0795c5c0d12ecbc3a9bd459f69780294fd60fb2145c858d55a357b193ece6baeR431-R432)

### Migration Changes:
* Added a new migration `20250225050130_AddColumnCodeAndIcon` to handle the addition of `Code` and `Icon` columns to the `Category` and `Subcategory` tables and updated the foreign key constraint for `FinancialGoal`.