### PR TITLE
fix(userspendingmodel) & feat(financialgoal): add CRUD API for financial goal + check FinancialGoal relate to Subcategory before canceling

### DIFF
--- a/MoneyEz.API/Controllers/FinancialGoalsController.cs
+++ b/MoneyEz.API/Controllers/FinancialGoalsController.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MoneyEz.Repositories.Commons;
+using MoneyEz.Repositories.Enums;
+using MoneyEz.Services.BusinessModels.FinancialGoalModels;
+using MoneyEz.Services.Services.Interfaces;
+using System;
+using System.Threading.Tasks;
+
+namespace MoneyEz.API.Controllers
+{
+    [Route("api/v1/financial-goals")]
+    [ApiController]
+    [Authorize(Roles = nameof(RolesEnum.USER))]
+    public class FinancialGoalsController : BaseController
+    {
+        private readonly IFinancialGoalService _financialGoalService;
+
+        public FinancialGoalsController(IFinancialGoalService financialGoalService)
+        {
+            _financialGoalService = financialGoalService;
+        }
+
+        #region Personal Financial Goals
+
+        [HttpPost("personal")]
+
+        public Task<IActionResult> AddPersonalFinancialGoal([FromBody] AddPersonalFinancialGoalModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.AddPersonalFinancialGoalAsync(model));
+        }
+
+        [HttpGet("personal")]
+
+        public Task<IActionResult> GetPersonalFinancialGoals([FromQuery] PaginationParameter paginationParameter)
+        {
+            return ValidateAndExecute(() => _financialGoalService.GetPersonalFinancialGoalsAsync(paginationParameter));
+        }
+
+        [HttpPost("personal/detail")]
+
+        public Task<IActionResult> GetPersonalFinancialGoalById([FromBody] GetPersonalFinancialGoalDetailModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.GetPersonalFinancialGoalByIdAsync(model));
+        }
+
+        [HttpPut("personal")]
+
+        public Task<IActionResult> UpdatePersonalFinancialGoal([FromBody] UpdatePersonalFinancialGoalModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.UpdatePersonalFinancialGoalAsync(model));
+        }
+
+        [HttpDelete("personal")]
+
+        public Task<IActionResult> DeletePersonalFinancialGoal([FromBody] DeleteFinancialGoalModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.DeletePersonalFinancialGoalAsync(model));
+        }
+
+        #endregion
+
+        #region Group Financial Goals
+
+        [HttpPost("group")]
+        public Task<IActionResult> AddGroupFinancialGoal([FromBody] AddGroupFinancialGoalModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.AddGroupFinancialGoalAsync(model));
+        }
+
+        [HttpGet("group")]
+        public Task<IActionResult> GetGroupFinancialGoals([FromQuery] GetGroupFinancialGoalsModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.GetGroupFinancialGoalsAsync(model));
+        }
+
+        [HttpPost("group/detail")]
+        public Task<IActionResult> GetGroupFinancialGoalById([FromBody] GetGroupFinancialGoalDetailModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.GetGroupFinancialGoalByIdAsync(model));
+        }
+
+        [HttpPut("group")]
+        public Task<IActionResult> UpdateGroupFinancialGoal([FromBody] UpdateGroupFinancialGoalModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.UpdateGroupFinancialGoalAsync(model));
+        }
+
+        [HttpDelete("group")]
+        public Task<IActionResult> DeleteGroupFinancialGoal([FromBody] DeleteFinancialGoalModel model)
+        {
+            return ValidateAndExecute(() => _financialGoalService.DeleteGroupFinancialGoalAsync(model));
+        }
+
+        #endregion
+    }
+}

--- a/MoneyEz.API/DependencyInjection.cs
+++ b/MoneyEz.API/DependencyInjection.cs
@@ -151,6 +151,9 @@ namespace MoneyEz.API
             services.AddScoped<IUserSpendingModelService, UserSpendingModelService>();
             services.AddScoped<IUserSpendingModelRepository, UserSpendingModelRepository>();
 
+            //config financial goal
+            services.AddScoped<IFinancialGoalRepository, FinancialGoalRepository>();
+
             //config spending model category service
             services.AddScoped<ISpendingModelCategoryRepository, SpendingModelCategoryRepository>();
 

--- a/MoneyEz.API/DependencyInjection.cs
+++ b/MoneyEz.API/DependencyInjection.cs
@@ -153,6 +153,7 @@ namespace MoneyEz.API
 
             //config financial goal
             services.AddScoped<IFinancialGoalRepository, FinancialGoalRepository>();
+            services.AddScoped<IFinancialGoalService, FinancialGoalService>();
 
             //config spending model category service
             services.AddScoped<ISpendingModelCategoryRepository, SpendingModelCategoryRepository>();

--- a/MoneyEz.Repositories/Entities/FinancialGoal.cs
+++ b/MoneyEz.Repositories/Entities/FinancialGoal.cs
@@ -18,7 +18,7 @@ public partial class FinancialGoal : BaseEntity
 
     public decimal TargetAmount { get; set; }
 
-    public decimal? CurrentAmount { get; set; }
+    public decimal CurrentAmount { get; set; }
 
     public DateTime Deadline { get; set; }
 

--- a/MoneyEz.Repositories/Entities/GroupFund.cs
+++ b/MoneyEz.Repositories/Entities/GroupFund.cs
@@ -13,7 +13,7 @@ public partial class GroupFund : BaseEntity
 
     public string Description { get; set; }
 
-    public decimal? CurrentBalance { get; set; }
+    public decimal CurrentBalance { get; set; }
 
     public CommonsStatus? Status { get; set; }
 

--- a/MoneyEz.Repositories/Repositories/Implements/FinancialGoalRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Implements/FinancialGoalRepository.cs
@@ -1,0 +1,12 @@
+﻿using MoneyEz.Repositories.Entities;
+using MoneyEz.Repositories.Repositories.Interfaces;
+
+namespace MoneyEz.Repositories.Repositories.Implements
+{
+    public class FinancialGoalRepository : GenericRepository<FinancialGoal>, IFinancialGoalRepository
+    {
+        public FinancialGoalRepository(MoneyEzContext context) : base(context)
+        {
+        }
+    }
+}

--- a/MoneyEz.Repositories/Repositories/Interfaces/IFinancialGoalRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Interfaces/IFinancialGoalRepository.cs
@@ -1,0 +1,8 @@
+﻿using MoneyEz.Repositories.Entities;
+
+namespace MoneyEz.Repositories.Repositories.Interfaces
+{
+    public interface IFinancialGoalRepository : IGenericRepository<FinancialGoal>
+    {
+    }
+}

--- a/MoneyEz.Repositories/UnitOfWork/IUnitOfWork.cs
+++ b/MoneyEz.Repositories/UnitOfWork/IUnitOfWork.cs
@@ -22,6 +22,9 @@ namespace MoneyEz.Repositories.UnitOfWork
         //spending model category
         ISpendingModelCategoryRepository SpendingModelCategoryRepository { get; }
 
+        //financialgoal
+        IFinancialGoalRepository FinancialGoalRepository { get; } 
+
         //category
         ICategoriesRepository CategoriesRepository { get; }
 

--- a/MoneyEz.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/MoneyEz.Repositories/UnitOfWork/UnitOfWork.cs
@@ -24,6 +24,9 @@ namespace MoneyEz.Repositories.UnitOfWork
         //user spending model
         private IUserSpendingModelRepository _userSpendingModelRepository;
 
+        //financial goal
+        private IFinancialGoalRepository _financialGoalRepository;
+
         //spending model category
         private ISpendingModelCategoryRepository _spendingModelCategoryRepository;
 
@@ -82,6 +85,15 @@ namespace MoneyEz.Repositories.UnitOfWork
                 return _spendingModelRepository ??= new SpendingModelRepository(_context);
             }
         }
+
+        public IFinancialGoalRepository FinancialGoalRepository
+        {
+            get
+            {
+                return _financialGoalRepository ??= new FinancialGoalRepository(_context);
+            }
+        }
+
 
         public IUserSpendingModelRepository UserSpendingModelRepository
         {

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/AddGroupFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/AddGroupFinancialGoalModel.cs
@@ -1,0 +1,26 @@
+﻿using MoneyEz.Services.Utils;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class AddGroupFinancialGoalModel
+    {
+        [Required]
+        public Guid GroupId { get; set; }
+
+        [Required]
+        public required string Name { get; set; }
+
+        public string NameUnsign => StringUtils.ConvertToUnSign(Name);
+
+        [Required]
+        [Range(0.01, double.MaxValue, ErrorMessage = "Số tiền mục tiêu phải lớn hơn 0.")]
+        public decimal TargetAmount { get; set; }
+
+        public decimal CurrentAmount { get; set; }
+
+        [Required]
+        public DateTime Deadline { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/AddPersonalFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/AddPersonalFinancialGoalModel.cs
@@ -15,7 +15,7 @@ namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
         public string NameUnsign => StringUtils.ConvertToUnSign(Name);
 
         [Required]
-        [Range(0.01, double.MaxValue, ErrorMessage = "Số tiền mục tiêu phải lớn hơn 0.")]
+        [Range(0.01, double.MaxValue, ErrorMessage = "Target amount must be greater than 0.")]
         public decimal TargetAmount { get; set; }
 
         public decimal CurrentAmount { get; set; } = 0;

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/AddPersonalFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/AddPersonalFinancialGoalModel.cs
@@ -1,0 +1,26 @@
+﻿using MoneyEz.Services.Utils;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class AddPersonalFinancialGoalModel
+    {
+        [Required]
+        public Guid SubcategoryId { get; set; }
+
+        [Required]
+        public required string Name { get; set; }
+
+        public string NameUnsign => StringUtils.ConvertToUnSign(Name);
+
+        [Required]
+        [Range(0.01, double.MaxValue, ErrorMessage = "Số tiền mục tiêu phải lớn hơn 0.")]
+        public decimal TargetAmount { get; set; }
+
+        public decimal CurrentAmount { get; set; } = 0;
+
+        [Required]
+        public DateTime Deadline { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/DeleteFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/DeleteFinancialGoalModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class DeleteFinancialGoalModel
+    {
+        [Required]
+        public Guid Id { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/GetGroupFinancialGoalDetailModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/GetGroupFinancialGoalDetailModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class GetGroupFinancialGoalDetailModel
+    {
+        [Required]
+        public Guid GroupId { get; set; }
+
+        [Required]
+        public Guid GoalId { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/GetGroupFinancialGoalsModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/GetGroupFinancialGoalsModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class GetGroupFinancialGoalsModel
+    {
+        [Required]
+        public Guid GroupId { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/GetPersonalFinancialGoalDetailModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/GetPersonalFinancialGoalDetailModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class GetPersonalFinancialGoalDetailModel
+    {
+        [Required]
+        public Guid GoalId { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/GroupFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/GroupFinancialGoalModel.cs
@@ -1,0 +1,17 @@
+﻿using MoneyEz.Repositories.Entities;
+using MoneyEz.Services.Utils;
+using System;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class GroupFinancialGoalModel : BaseEntity
+    {
+        public Guid UserId { get; set; }
+        public Guid GroupId { get; set; }
+        public required string Name { get; set; }
+        public required string NameUnsign { get; set; }
+        public decimal TargetAmount { get; set; }
+        public decimal CurrentAmount { get; set; }
+        public DateTime Deadline { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/PersonalFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/PersonalFinancialGoalModel.cs
@@ -1,0 +1,17 @@
+﻿using MoneyEz.Repositories.Entities;
+using MoneyEz.Services.Utils;
+using System;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class PersonalFinancialGoalModel : BaseEntity
+    {
+        public Guid UserId { get; set; }
+        public Guid SubcategoryId { get; set; }
+        public string Name { get; set; }
+        public string NameUnsign { get; set; }
+        public decimal TargetAmount { get; set; }
+        public decimal CurrentAmount { get; set; } = 0;
+        public DateTime Deadline { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdateGroupFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdateGroupFinancialGoalModel.cs
@@ -20,8 +20,6 @@ namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
         [Range(0.01, double.MaxValue, ErrorMessage = "Số tiền mục tiêu phải lớn hơn 0.")]
         public decimal TargetAmount { get; set; }
 
-        public decimal CurrentAmount { get; set; }
-
         [Required]
         public DateTime Deadline { get; set; }
     }

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdateGroupFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdateGroupFinancialGoalModel.cs
@@ -1,0 +1,28 @@
+﻿using MoneyEz.Services.Utils;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class UpdateGroupFinancialGoalModel
+    {
+        [Required]
+        public Guid Id { get; set; }
+
+        [Required]
+        public Guid GroupId { get; set; }
+
+        [Required]
+        public required string Name { get; set; }
+
+        public string NameUnsign => StringUtils.ConvertToUnSign(Name);
+
+        [Range(0.01, double.MaxValue, ErrorMessage = "Số tiền mục tiêu phải lớn hơn 0.")]
+        public decimal TargetAmount { get; set; }
+
+        public decimal CurrentAmount { get; set; }
+
+        [Required]
+        public DateTime Deadline { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdatePersonalFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdatePersonalFinancialGoalModel.cs
@@ -1,0 +1,25 @@
+﻿using MoneyEz.Services.Utils;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
+{
+    public class UpdatePersonalFinancialGoalModel
+    {
+        [Required]
+        public Guid Id { get; set; }
+
+        [Required]
+        public string Name { get; set; }
+
+        public string NameUnsign => StringUtils.ConvertToUnSign(Name);
+
+        [Range(0.01, double.MaxValue, ErrorMessage = "Số tiền mục tiêu phải lớn hơn 0.")]
+        public decimal TargetAmount { get; set; }
+
+        public decimal CurrentAmount { get; set; }
+
+        [Required]
+        public DateTime Deadline { get; set; }
+    }
+}

--- a/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdatePersonalFinancialGoalModel.cs
+++ b/MoneyEz.Services/BusinessModels/FinancialGoalModels/UpdatePersonalFinancialGoalModel.cs
@@ -17,8 +17,6 @@ namespace MoneyEz.Services.BusinessModels.FinancialGoalModels
         [Range(0.01, double.MaxValue, ErrorMessage = "Số tiền mục tiêu phải lớn hơn 0.")]
         public decimal TargetAmount { get; set; }
 
-        public decimal CurrentAmount { get; set; }
-
         [Required]
         public DateTime Deadline { get; set; }
     }

--- a/MoneyEz.Services/Constants/MessageConstants.cs
+++ b/MoneyEz.Services/Constants/MessageConstants.cs
@@ -70,6 +70,23 @@ namespace MoneyEz.Services.Constants
         public const string CURRENT_SPENDING_MODEL_NOT_FINISHED = "CurrentSpendingModelNotFinished";
         public const string CANNOT_CANCEL_SPENDING_MODEL_HAS_GOALS = "CannotCancelSpendingModelHasGoals";
 
+        //financial goal
+        public const string USER_HAS_NO_ACTIVE_SPENDING_MODEL = "UserHasNoActiveSpendingModel";
+        public const string SUBCATEGORY_NOT_IN_SPENDING_MODEL = "SubcategoryNotInSpendingModel";
+        public const string SUBCATEGORY_ALREADY_HAS_GOAL = "SubcategoryAlreadyHasGoal";
+        public const string FINANCIAL_GOAL_NOT_FOUND = "FinancialGoalNotFound";
+        public const string FINANCIAL_GOAL_ACCESS_DENIED = "FinancialGoalAccessDenied";
+        public const string INVALID_TARGET_AMOUNT = "InvalidTargetAmount";
+
+        public const string USER_NOT_IN_GROUP = "UserNotInGroup";
+        public const string USER_NOT_AUTHORIZED = "UserNotAuthorized";
+        public const string GROUP_ALREADY_HAS_GOAL = "GroupAlreadyHasGoal";
+        public const string GROUP_NOT_FOUND = "GroupNotFound";
+        public const string FINANCIAL_GOAL_NOT_IN_GROUP = "FinancialGoalNotInGroup";
+        public const string INSUFFICIENT_GROUP_FUNDS = "InsufficientGroupFunds";
+        public const string GOAL_NOT_COMPLETED = "GoalNotCompleted";
+
+
         // category
         public const string CATEGORY_ALREADY_EXISTS = "CategoryAlreadyExists";
         public const string CATEGORY_CREATED_SUCCESS = "CategoryCreatedSuccessfully";
@@ -135,6 +152,7 @@ namespace MoneyEz.Services.Constants
         public const string GROUP_GET_ALL_SUCCESS_MESSAGE = "Group get all successfully";
         public const string GROUP_CLOSE_FAIL = "GroupCloseFailed";
         public const string GROUP_CLOSE_SUCCESS_MESSAGE = "Group closed successfully";
+        public const string GROUP_ACCESS_DENIED = "GroupAccessDenied";
 
         public const string GROUP_CLOSE_FORBIDDEN = "GroupCloseForbidden";
         public const string GROUP_REMOVE_MEMBER_FORBIDDEN = "GroupMemberNotFound";
@@ -196,7 +214,7 @@ namespace MoneyEz.Services.Constants
 
         // bank account
         public const string BANK_ACCOUNT_NOT_FOUND = "BankAccountNotFound";
-        public const string BANK_ACCOUNT_ALREADY_EXISTS = "BankAccountAlreadyExists"; 
+        public const string BANK_ACCOUNT_ALREADY_EXISTS = "BankAccountAlreadyExists";
         public const string BANK_ACCOUNT_ACCESS_DENIED = "BankAccountAccessDenied";
         public const string BANK_ACCOUNT_NUMBER_DUPLICATE = "BankAccountNumberDuplicate";
         public const string BANK_ACCOUNT_REGISTERED_IN_GROUP = "BankAccountRegisteredInGroup";
@@ -204,7 +222,7 @@ namespace MoneyEz.Services.Constants
         public const string BANK_ACCOUNT_LIST_GET_SUCCESS_MESSAGE = "Bank account list fetched successfully";
         public const string BANK_ACCOUNT_GET_SUCCESS_MESSAGE = "Bank account details fetched successfully";
         public const string BANK_ACCOUNT_CREATE_SUCCESS_MESSAGE = "Bank account created successfully";
-        public const string BANK_ACCOUNT_UPDATE_SUCCESS_MESSAGE = "Bank account updated successfully"; 
+        public const string BANK_ACCOUNT_UPDATE_SUCCESS_MESSAGE = "Bank account updated successfully";
         public const string BANK_ACCOUNT_DELETE_SUCCESS_MESSAGE = "Bank account deleted successfully";
     }
 }

--- a/MoneyEz.Services/Constants/MessageConstants.cs
+++ b/MoneyEz.Services/Constants/MessageConstants.cs
@@ -77,6 +77,8 @@ namespace MoneyEz.Services.Constants
         public const string FINANCIAL_GOAL_NOT_FOUND = "FinancialGoalNotFound";
         public const string FINANCIAL_GOAL_ACCESS_DENIED = "FinancialGoalAccessDenied";
         public const string INVALID_TARGET_AMOUNT = "InvalidTargetAmount";
+        public const string INVALID_DEADLINE = "InvalidDeadline";
+        public const string SPENDING_MODEL_DATA_MISSING = "SpendingModelDataMissing";
 
         public const string USER_NOT_IN_GROUP = "UserNotInGroup";
         public const string USER_NOT_AUTHORIZED = "UserNotAuthorized";
@@ -85,7 +87,9 @@ namespace MoneyEz.Services.Constants
         public const string FINANCIAL_GOAL_NOT_IN_GROUP = "FinancialGoalNotInGroup";
         public const string INSUFFICIENT_GROUP_FUNDS = "InsufficientGroupFunds";
         public const string GOAL_NOT_COMPLETED = "GoalNotCompleted";
-
+        public const string INVALID_SPENDING_MODEL = "InvalidSpendingModel";
+        public const string SPENDING_MODEL_HAS_NO_CATEGORIES = "SpendingModelHasNoCategories";
+        public const string SPENDING_MODEL_HAS_NO_SUBCATEGORIES = "SpendingModelHasNoSubcategories";
 
         // category
         public const string CATEGORY_ALREADY_EXISTS = "CategoryAlreadyExists";

--- a/MoneyEz.Services/Constants/MessageConstants.cs
+++ b/MoneyEz.Services/Constants/MessageConstants.cs
@@ -68,6 +68,7 @@ namespace MoneyEz.Services.Constants
         public const string INVALID_PERIOD_UNIT = "InvalidPeriodUnit";
         public const string USER_ALREADY_HAS_ACTIVE_SPENDING_MODEL = "UserAlreadyHasActiveSpendingModel";
         public const string CURRENT_SPENDING_MODEL_NOT_FINISHED = "CurrentSpendingModelNotFinished";
+        public const string CANNOT_CANCEL_SPENDING_MODEL_HAS_GOALS = "CannotCancelSpendingModelHasGoals";
 
         // category
         public const string CATEGORY_ALREADY_EXISTS = "CategoryAlreadyExists";

--- a/MoneyEz.Services/Constants/MessageConstants.cs
+++ b/MoneyEz.Services/Constants/MessageConstants.cs
@@ -69,6 +69,9 @@ namespace MoneyEz.Services.Constants
         public const string USER_ALREADY_HAS_ACTIVE_SPENDING_MODEL = "UserAlreadyHasActiveSpendingModel";
         public const string CURRENT_SPENDING_MODEL_NOT_FINISHED = "CurrentSpendingModelNotFinished";
         public const string CANNOT_CANCEL_SPENDING_MODEL_HAS_GOALS = "CannotCancelSpendingModelHasGoals";
+        public const string START_DATE_CANNOT_BE_IN_PAST = "StartDateCannotBeInPast";
+        public const string END_DATE_MUST_BE_AFTER_START_DATE = "EndDateMustBeAfterStartDate";
+        public const string CANNOT_SELECT_FUTURE_MODEL_WHEN_ACTIVE = "CannotSelectFutureModelWhenActive";
 
         //financial goal
         public const string USER_HAS_NO_ACTIVE_SPENDING_MODEL = "UserHasNoActiveSpendingModel";

--- a/MoneyEz.Services/Constants/MessageConstants.cs
+++ b/MoneyEz.Services/Constants/MessageConstants.cs
@@ -93,6 +93,7 @@ namespace MoneyEz.Services.Constants
         public const string INVALID_SPENDING_MODEL = "InvalidSpendingModel";
         public const string SPENDING_MODEL_HAS_NO_CATEGORIES = "SpendingModelHasNoCategories";
         public const string SPENDING_MODEL_HAS_NO_SUBCATEGORIES = "SpendingModelHasNoSubcategories";
+        public const string FINANCIAL_GOAL_CANNOT_BE_DELETED = "FinancialGoalCannotBeDeleted";
 
         // category
         public const string CATEGORY_ALREADY_EXISTS = "CategoryAlreadyExists";

--- a/MoneyEz.Services/Mappers/FinancialGoalMapperConfig.cs
+++ b/MoneyEz.Services/Mappers/FinancialGoalMapperConfig.cs
@@ -1,0 +1,40 @@
+﻿using AutoMapper;
+using MoneyEz.Repositories.Entities;
+using MoneyEz.Repositories.Commons;
+using MoneyEz.Services.BusinessModels.FinancialGoalModels;
+using MoneyEz.Services.Utils;
+
+namespace MoneyEz.Services.Mappers
+{
+    public partial class MapperConfig
+    {
+        partial void FinancialGoalMapperConfig()
+        {
+            // Mapping cho Financial Goal cá nhân
+            CreateMap<FinancialGoal, PersonalFinancialGoalModel>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => src.NameUnsign));
+
+            CreateMap<AddPersonalFinancialGoalModel, FinancialGoal>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => StringUtils.ConvertToUnSign(src.Name)));
+
+            CreateMap<UpdatePersonalFinancialGoalModel, FinancialGoal>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => StringUtils.ConvertToUnSign(src.Name)));
+
+            CreateMap<Pagination<FinancialGoal>, Pagination<PersonalFinancialGoalModel>>()
+                .ConvertUsing<PaginationConverter<FinancialGoal, PersonalFinancialGoalModel>>();
+
+            // Mapping cho Financial Goal nhóm
+            CreateMap<FinancialGoal, GroupFinancialGoalModel>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => src.NameUnsign));
+
+            CreateMap<AddGroupFinancialGoalModel, FinancialGoal>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => StringUtils.ConvertToUnSign(src.Name)));
+
+            CreateMap<UpdateGroupFinancialGoalModel, FinancialGoal>()
+                .ForMember(dest => dest.NameUnsign, opt => opt.MapFrom(src => StringUtils.ConvertToUnSign(src.Name)));
+
+            CreateMap<Pagination<FinancialGoal>, Pagination<GroupFinancialGoalModel>>()
+                .ConvertUsing<PaginationConverter<FinancialGoal, GroupFinancialGoalModel>>();
+        }
+    }
+}

--- a/MoneyEz.Services/Mappers/MapperConfig.cs
+++ b/MoneyEz.Services/Mappers/MapperConfig.cs
@@ -20,6 +20,10 @@ namespace MoneyEz.Services.Mappers
             SpendingModelMapperConfig();
             // user spending model mapper
             UserSpendingModelMapperConfig();
+
+            //financialgoal
+            FinancialGoalMapperConfig();
+
             //category mapper
             CategoryMapperConfig();
             //subcategory mapper
@@ -50,6 +54,7 @@ namespace MoneyEz.Services.Mappers
         partial void UserMapperConfig();
         partial void SpendingModelMapperConfig();
         partial void UserSpendingModelMapperConfig();
+        partial void FinancialGoalMapperConfig();
         partial void CategoryMapperConfig();
         partial void SubcategoryMapperConfig();
         partial void TransactionMapperConfig();

--- a/MoneyEz.Services/Services/Implements/FinancialGoalService.cs
+++ b/MoneyEz.Services/Services/Implements/FinancialGoalService.cs
@@ -138,7 +138,7 @@ namespace MoneyEz.Services.Services.Implements
 
             var financialGoals = await _unitOfWork.FinancialGoalRepository.ToPaginationIncludeAsync(
                 paginationParameter,
-                filter: fg => fg.UserId == user.Id
+                filter: fg => fg.UserId == user.Id && fg.GroupId == null
             );
 
             var mappedGoals = _mapper.Map<List<PersonalFinancialGoalModel>>(financialGoals);

--- a/MoneyEz.Services/Services/Implements/FinancialGoalService.cs
+++ b/MoneyEz.Services/Services/Implements/FinancialGoalService.cs
@@ -1,0 +1,514 @@
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using MoneyEz.Repositories.Commons;
+using MoneyEz.Repositories.Entities;
+using MoneyEz.Repositories.Enums;
+using MoneyEz.Repositories.UnitOfWork;
+using MoneyEz.Repositories.Utils;
+using MoneyEz.Services.BusinessModels.CategoryModels;
+using MoneyEz.Services.BusinessModels.FinancialGoalModels;
+using MoneyEz.Services.BusinessModels.ResultModels;
+using MoneyEz.Services.Constants;
+using MoneyEz.Services.Exceptions;
+using MoneyEz.Services.Services.Interfaces;
+using MoneyEz.Services.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MoneyEz.Services.Services.Implements
+{
+    public class FinancialGoalService : IFinancialGoalService
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+        private readonly IClaimsService _claimsService;
+
+        public FinancialGoalService(
+            IUnitOfWork unitOfWork,
+            IMapper mapper,
+            IClaimsService claimsService)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+            _claimsService = claimsService;
+        }
+
+        #region Personal
+        public async Task<BaseResultModel> AddPersonalFinancialGoalAsync(AddPersonalFinancialGoalModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            var activeSpendingModels = await _unitOfWork.UserSpendingModelRepository.ToPaginationIncludeAsync(
+                new PaginationParameter { PageSize = 1, PageIndex = 1 },
+                filter: usm => usm.UserId == user.Id && usm.EndDate > CommonUtils.GetCurrentTime() && !usm.IsDeleted
+            );
+
+            if (!activeSpendingModels.Any())
+            {
+                throw new DefaultException("User does not have an active spending model.", MessageConstants.USER_HAS_NO_ACTIVE_SPENDING_MODEL);
+            }
+
+            var existingGoals = await _unitOfWork.FinancialGoalRepository.ToPaginationIncludeAsync(
+                new PaginationParameter { PageSize = 1, PageIndex = 1 },
+                filter: fg => fg.UserId == user.Id && fg.SubcategoryId == model.SubcategoryId
+            );
+
+            if (existingGoals.Any())
+            {
+                throw new DefaultException("A financial goal already exists for this subcategory.", MessageConstants.SUBCATEGORY_ALREADY_HAS_GOAL);
+            }
+
+            var financialGoal = _mapper.Map<FinancialGoal>(model);
+            financialGoal.UserId = user.Id;
+            financialGoal.CreatedDate = CommonUtils.GetCurrentTime();
+
+            await _unitOfWork.FinancialGoalRepository.AddAsync(financialGoal);
+            await _unitOfWork.SaveAsync();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status201Created,
+                Message = "Financial goal created successfully."
+            };
+        }
+        public async Task<BaseResultModel> GetPersonalFinancialGoalsAsync(PaginationParameter paginationParameter)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            var financialGoals = await _unitOfWork.FinancialGoalRepository.ToPaginationIncludeAsync(
+                paginationParameter,
+                filter: fg => fg.UserId == user.Id
+            );
+
+            var mappedGoals = _mapper.Map<List<PersonalFinancialGoalModel>>(financialGoals);
+
+            var paginatedResult = new Pagination<PersonalFinancialGoalModel>(
+                mappedGoals,
+                financialGoals.TotalCount,
+                financialGoals.CurrentPage,
+                financialGoals.PageSize
+            );
+
+            var metaData = new
+            {
+                financialGoals.TotalCount,
+                financialGoals.PageSize,
+                financialGoals.CurrentPage,
+                financialGoals.TotalPages,
+                financialGoals.HasNext,
+                financialGoals.HasPrevious
+            };
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Data = new
+                {
+                    Data = paginatedResult,
+                    MetaData = metaData
+                }
+            };
+        }
+        public async Task<BaseResultModel> GetPersonalFinancialGoalByIdAsync(GetPersonalFinancialGoalDetailModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            var financialGoal = await _unitOfWork.FinancialGoalRepository.GetByIdAsync(model.GoalId)
+                ?? throw new NotExistException(MessageConstants.FINANCIAL_GOAL_NOT_FOUND);
+
+            if (financialGoal.UserId != user.Id)
+            {
+                throw new DefaultException("Access denied.", MessageConstants.FINANCIAL_GOAL_ACCESS_DENIED);
+            }
+
+            var mappedGoal = _mapper.Map<PersonalFinancialGoalModel>(financialGoal);
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Data = mappedGoal
+            };
+        }
+        public async Task<BaseResultModel> UpdatePersonalFinancialGoalAsync(UpdatePersonalFinancialGoalModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            var financialGoal = await _unitOfWork.FinancialGoalRepository.GetByIdAsync(model.Id)
+                ?? throw new NotExistException(MessageConstants.FINANCIAL_GOAL_NOT_FOUND);
+
+            if (financialGoal.UserId != user.Id)
+            {
+                throw new DefaultException("Access denied.", MessageConstants.FINANCIAL_GOAL_ACCESS_DENIED);
+            }
+
+            // Kiểm tra TargetAmount không được nhỏ hơn CurrentAmount
+            if (model.TargetAmount < financialGoal.CurrentAmount)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.INVALID_TARGET_AMOUNT,
+                    Message = "Target amount cannot be less than the current amount."
+                };
+            }
+
+            financialGoal.Name = model.Name;
+            financialGoal.NameUnsign = StringUtils.ConvertToUnSign(model.Name);
+            financialGoal.TargetAmount = model.TargetAmount;
+            financialGoal.CurrentAmount = model.CurrentAmount;
+            financialGoal.Deadline = model.Deadline;
+            financialGoal.UpdatedDate = CommonUtils.GetCurrentTime();
+
+            _unitOfWork.FinancialGoalRepository.UpdateAsync(financialGoal);
+            await _unitOfWork.SaveAsync();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = "Financial goal updated successfully."
+            };
+        }
+        public async Task<BaseResultModel> DeletePersonalFinancialGoalAsync(DeleteFinancialGoalModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            var financialGoal = await _unitOfWork.FinancialGoalRepository.GetByIdAsync(model.Id)
+                ?? throw new NotExistException(MessageConstants.FINANCIAL_GOAL_NOT_FOUND);
+
+            if (financialGoal.UserId != user.Id)
+            {
+                throw new DefaultException("Access denied.", MessageConstants.FINANCIAL_GOAL_ACCESS_DENIED);
+            }
+
+            _unitOfWork.FinancialGoalRepository.SoftDeleteAsync(financialGoal);
+            await _unitOfWork.SaveAsync();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = "Financial goal deleted successfully."
+            };
+        }
+
+        #endregion Personal
+
+        #region Group
+        public async Task<BaseResultModel> AddGroupFinancialGoalAsync(AddGroupFinancialGoalModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            // Kiểm tra xem user có trong nhóm không và có phải Leader/Mod không
+            var groupMember = await _unitOfWork.GroupMemberRepository.GetByConditionAsync(
+                filter: gm => gm.GroupId == model.GroupId && gm.UserId == user.Id
+            );
+
+            if (!groupMember.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_IN_GROUP,
+                    Message = "User is not a member of this group."
+                };
+            }
+
+            var userRole = groupMember.First().Role;
+            if (userRole != RoleGroup.LEADER && userRole != RoleGroup.MOD)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_AUTHORIZED,
+                    Message = "Only group leaders or moderators can create financial goals for the group."
+                };
+            }
+
+            // Kiểm tra xem nhóm đã có Goal chưa
+            var existingGoals = await _unitOfWork.FinancialGoalRepository.ToPaginationIncludeAsync(
+                new PaginationParameter { PageSize = 1, PageIndex = 1 },
+                filter: fg => fg.GroupId == model.GroupId
+            );
+
+            if (existingGoals.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.GROUP_ALREADY_HAS_GOAL,
+                    Message = "The group already has an active financial goal."
+                };
+            }
+
+            // Kiểm tra xem GroupFund có đủ CurrentAmount không
+            var groupFund = await _unitOfWork.GroupFundRepository.GetByIdAsync(model.GroupId)
+                ?? throw new NotExistException(MessageConstants.GROUP_NOT_FOUND);
+
+            if (model.TargetAmount <= 0 || model.TargetAmount <= model.CurrentAmount)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.INVALID_TARGET_AMOUNT,
+                    Message = "Target amount must be greater than 0 and greater than current amount."
+                };
+            }
+
+            if (model.CurrentAmount > groupFund.CurrentBalance)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.INSUFFICIENT_GROUP_FUNDS,
+                    Message = "The group's current balance is insufficient for this financial goal."
+                };
+            }
+
+            // Tạo mới Financial Goal cho nhóm
+            var financialGoal = new FinancialGoal
+            {
+                UserId = user.Id,
+                GroupId = model.GroupId,
+                Name = model.Name,
+                NameUnsign = StringUtils.ConvertToUnSign(model.Name),
+                TargetAmount = model.TargetAmount,
+                CurrentAmount = model.CurrentAmount,
+                Deadline = model.Deadline,
+                CreatedDate = CommonUtils.GetCurrentTime()
+            };
+
+            await _unitOfWork.FinancialGoalRepository.AddAsync(financialGoal);
+            await _unitOfWork.SaveAsync();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status201Created,
+                Message = "Financial goal created successfully for the group."
+            };
+        }
+        public async Task<BaseResultModel> GetGroupFinancialGoalsAsync(GetGroupFinancialGoalsModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            // Kiểm tra xem user có trong nhóm không
+            var groupMember = await _unitOfWork.GroupMemberRepository.GetByConditionAsync(
+                filter: gm => gm.GroupId == model.GroupId && gm.UserId == user.Id
+            );
+
+            if (!groupMember.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_IN_GROUP,
+                    Message = "User is not a member of this group."
+                };
+            }
+
+            var financialGoals = await _unitOfWork.FinancialGoalRepository.ToPaginationIncludeAsync(
+                new PaginationParameter { PageSize = 10, PageIndex = 1 }, // Hoặc có thể điều chỉnh phân trang
+                filter: fg => fg.GroupId == model.GroupId
+            );
+
+            var mappedGoals = _mapper.Map<List<GroupFinancialGoalModel>>(financialGoals);
+
+            var paginatedResult = new Pagination<GroupFinancialGoalModel>(
+                mappedGoals,
+                financialGoals.TotalCount,
+                financialGoals.CurrentPage,
+                financialGoals.PageSize
+            );
+
+            var metaData = new
+            {
+                financialGoals.TotalCount,
+                financialGoals.PageSize,
+                financialGoals.CurrentPage,
+                financialGoals.TotalPages,
+                financialGoals.HasNext,
+                financialGoals.HasPrevious
+            };
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Data = new
+                {
+                    Data = paginatedResult,
+                    MetaData = metaData
+                }
+            };
+        }
+        public async Task<BaseResultModel> UpdateGroupFinancialGoalAsync(UpdateGroupFinancialGoalModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            var financialGoal = await _unitOfWork.FinancialGoalRepository.GetByIdAsync(model.Id)
+                ?? throw new NotExistException(MessageConstants.FINANCIAL_GOAL_NOT_FOUND);
+
+            // Kiểm tra xem user có trong nhóm không và có phải Leader/Mod không
+            var groupMember = await _unitOfWork.GroupMemberRepository.GetByConditionAsync(
+                filter: gm => gm.GroupId == financialGoal.GroupId && gm.UserId == user.Id
+            );
+
+            if (!groupMember.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_IN_GROUP,
+                    Message = "User is not a member of this group."
+                };
+            }
+
+            var userRole = groupMember.First().Role;
+            if (userRole != RoleGroup.LEADER && userRole != RoleGroup.MOD)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_AUTHORIZED,
+                    Message = "Only group leaders or moderators can update financial goals."
+                };
+            }
+
+            // Kiểm tra nếu TargetAmount bị giảm xuống dưới CurrentAmount
+            if (model.TargetAmount < financialGoal.CurrentAmount)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.INVALID_TARGET_AMOUNT,
+                    Message = "Target amount cannot be less than the current amount."
+                };
+            }
+
+            financialGoal.Name = model.Name;
+            financialGoal.NameUnsign = StringUtils.ConvertToUnSign(model.Name);
+            financialGoal.TargetAmount = model.TargetAmount;
+            financialGoal.CurrentAmount = model.CurrentAmount;
+            financialGoal.Deadline = model.Deadline;
+            financialGoal.UpdatedDate = CommonUtils.GetCurrentTime();
+
+            _unitOfWork.FinancialGoalRepository.UpdateAsync(financialGoal);
+            await _unitOfWork.SaveAsync();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = "Financial goal updated successfully."
+            };
+        }
+        public async Task<BaseResultModel> DeleteGroupFinancialGoalAsync(DeleteFinancialGoalModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            var financialGoal = await _unitOfWork.FinancialGoalRepository.GetByIdAsync(model.Id)
+                ?? throw new NotExistException(MessageConstants.FINANCIAL_GOAL_NOT_FOUND);
+
+            // Kiểm tra xem user có trong nhóm không và có phải Leader không
+            var groupMember = await _unitOfWork.GroupMemberRepository.GetByConditionAsync(
+                filter: gm => gm.GroupId == financialGoal.GroupId && gm.UserId == user.Id
+            );
+
+            if (!groupMember.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_IN_GROUP,
+                    Message = "User is not a member of this group."
+                };
+            }
+
+            var userRole = groupMember.First().Role;
+            if (userRole != RoleGroup.LEADER)
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_AUTHORIZED,
+                    Message = "Only group leaders can delete financial goals."
+                };
+            }
+
+            // Kiểm tra nếu Goal chưa hoàn thành hoặc chưa tới Deadline
+            if (financialGoal.TargetAmount > financialGoal.CurrentAmount || financialGoal.Deadline > CommonUtils.GetCurrentTime())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    ErrorCode = MessageConstants.GOAL_NOT_COMPLETED,
+                    Message = "Cannot delete an unfinished financial goal."
+                };
+            }
+
+            _unitOfWork.FinancialGoalRepository.SoftDeleteAsync(financialGoal);
+            await _unitOfWork.SaveAsync();
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Message = "Financial goal deleted successfully."
+            };
+        }
+        public async Task<BaseResultModel> GetGroupFinancialGoalByIdAsync(GetGroupFinancialGoalDetailModel model)
+        {
+            string userEmail = _claimsService.GetCurrentUserEmail;
+            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail)
+                ?? throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+
+            // Kiểm tra xem user có trong nhóm không
+            var groupMember = await _unitOfWork.GroupMemberRepository.GetByConditionAsync(
+                filter: gm => gm.GroupId == model.GroupId && gm.UserId == user.Id
+            );
+
+            if (!groupMember.Any())
+            {
+                return new BaseResultModel
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    ErrorCode = MessageConstants.USER_NOT_IN_GROUP,
+                    Message = "User is not a member of this group."
+                };
+            }
+
+            var financialGoal = await _unitOfWork.FinancialGoalRepository.GetByIdAsync(model.GoalId)
+                ?? throw new NotExistException(MessageConstants.FINANCIAL_GOAL_NOT_FOUND);
+
+            // Kiểm tra xem Goal có thuộc nhóm không
+            if (financialGoal.GroupId != model.GroupId)
+            {
+                throw new DefaultException("Financial goal does not belong to the specified group.", MessageConstants.FINANCIAL_GOAL_NOT_IN_GROUP);
+            }
+
+            var mappedGoal = _mapper.Map<GroupFinancialGoalModel>(financialGoal);
+
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Data = mappedGoal
+            };
+        }
+        #endregion Group
+    }
+}

--- a/MoneyEz.Services/Services/Interfaces/IFinancialGoalService.cs
+++ b/MoneyEz.Services/Services/Interfaces/IFinancialGoalService.cs
@@ -1,0 +1,23 @@
+﻿using MoneyEz.Repositories.Commons;
+using MoneyEz.Services.BusinessModels.FinancialGoalModels;
+using MoneyEz.Services.BusinessModels.ResultModels;
+using System;
+using System.Threading.Tasks;
+
+namespace MoneyEz.Services.Services.Interfaces
+{
+    public interface IFinancialGoalService
+    {
+        Task<BaseResultModel> AddPersonalFinancialGoalAsync(AddPersonalFinancialGoalModel model);
+        Task<BaseResultModel> GetPersonalFinancialGoalsAsync(PaginationParameter paginationParameter);
+        Task<BaseResultModel> GetPersonalFinancialGoalByIdAsync(GetPersonalFinancialGoalDetailModel model);
+        Task<BaseResultModel> UpdatePersonalFinancialGoalAsync(UpdatePersonalFinancialGoalModel model);
+        Task<BaseResultModel> DeletePersonalFinancialGoalAsync(DeleteFinancialGoalModel model);
+
+        Task<BaseResultModel> AddGroupFinancialGoalAsync(AddGroupFinancialGoalModel model);
+        Task<BaseResultModel> GetGroupFinancialGoalsAsync(GetGroupFinancialGoalsModel model);
+        Task<BaseResultModel> GetGroupFinancialGoalByIdAsync(GetGroupFinancialGoalDetailModel model);
+        Task<BaseResultModel> UpdateGroupFinancialGoalAsync(UpdateGroupFinancialGoalModel model);
+        Task<BaseResultModel> DeleteGroupFinancialGoalAsync(DeleteFinancialGoalModel model);
+    }
+}


### PR DESCRIPTION
****1.** Goal phải đi cùng với 1 subcategory tồn tại trong userspendingmodel đang sử dụng:**

Note cho FE

Khi cancel UserSpendingModel, kiểm tra Subcategory cũ có Goal không.

- Nếu có goal, hỏi user có muốn xóa Goal cũ không.
   + Nếu user không muốn xóa goal cũ thì giữ nguyên UserSpendingModel không cho đổi
   + Nếu user muốn xóa goal thì cho đổi
- Nếu không có goal, thì như cũ 
