### PR TITLE
fix(user-spending-model): change route for GetTransactionsByUserSpend…

### DIFF
--- a/MoneyEz.API/Controllers/TransactionsController.cs
+++ b/MoneyEz.API/Controllers/TransactionsController.cs
@@ -29,12 +29,6 @@ namespace MoneyEz.API.Controllers
         {
             return ValidateAndExecute(() => _transactionService.GetAllTransactionsForUserAsync(paginationParameter));
         }
-        
-        [HttpGet("user-spending-model/{userSpendingModelId}")]
-        public Task<IActionResult> GetAllTransactionsBySpendingModel([FromQuery] PaginationParameter paginationParameter, Guid userSpendingModelId)
-        {
-            return ValidateAndExecute(() => _transactionService.GetTransactionsByUserSpendingModelAsync(paginationParameter, userSpendingModelId));
-        }
 
         [Authorize(Roles = nameof(RolesEnum.USER))]
         [HttpGet("user/{transactionId}")]

--- a/MoneyEz.API/Controllers/UserSpendingModelsController.cs
+++ b/MoneyEz.API/Controllers/UserSpendingModelsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using MoneyEz.Repositories.Commons;
 using MoneyEz.Repositories.Enums;
 using MoneyEz.Services.BusinessModels.SpendingModelModels;
+using MoneyEz.Services.Services.Implements;
 using MoneyEz.Services.Services.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -70,6 +71,13 @@ namespace MoneyEz.API.Controllers
         public Task<IActionResult> GetUsedSpendingModels([FromQuery] PaginationParameter paginationParameter)
         {
             return ValidateAndExecute(() => _userSpendingModelService.GetUsedSpendingModelsPaginationAsync(paginationParameter));
+        }
+
+
+        [HttpGet("transactions/{id}")]
+        public Task<IActionResult> GetAllTransactionsBySpendingModel([FromQuery] PaginationParameter paginationParameter, Guid id)
+        {
+            return ValidateAndExecute(() => _userSpendingModelService.GetTransactionsByUserSpendingModelAsync(paginationParameter, id));
         }
     }
 }

--- a/MoneyEz.Services/Services/Implements/TransactionService.cs
+++ b/MoneyEz.Services/Services/Implements/TransactionService.cs
@@ -604,62 +604,6 @@ namespace MoneyEz.Services.Services.Implements
             };
         }
 
-        public async Task<BaseResultModel> GetTransactionsByUserSpendingModelAsync(PaginationParameter paginationParameter, Guid userSpendingModelId)
-        {
-            string userEmail = _claimsService.GetCurrentUserEmail;
-            if (string.IsNullOrEmpty(userEmail))
-            {
-                return new BaseResultModel
-                {
-                    Status = StatusCodes.Status401Unauthorized,
-                    ErrorCode = MessageConstants.TOKEN_NOT_VALID,
-                    Message = "Unauthorized: Cannot retrieve user email."
-                };
-            }
-
-            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(userEmail);
-            if (user == null)
-            {
-                return new BaseResultModel
-                {
-                    Status = StatusCodes.Status404NotFound,
-                    ErrorCode = MessageConstants.ACCOUNT_NOT_EXIST,
-                    Message = "User not found."
-                };
-            }
-
-            var userSpendingModel = await _unitOfWork.UserSpendingModelRepository.GetByIdAsync(userSpendingModelId);
-            if (userSpendingModel == null || userSpendingModel.UserId != user.Id)
-            {
-                return new BaseResultModel
-                {
-                    Status = StatusCodes.Status404NotFound,
-                    ErrorCode = MessageConstants.SPENDING_MODEL_NOT_FOUND,
-                    Message = "Spending model not found for the user."
-                };
-            }
-
-            var transactions = await _unitOfWork.TransactionsRepository.ToPaginationIncludeAsync(
-                paginationParameter,
-                include: query => query.Include(t => t.Subcategory),
-                filter: t => t.UserId == user.Id
-                             && t.TransactionDate >= userSpendingModel.StartDate
-                             && t.TransactionDate <= userSpendingModel.EndDate,
-                orderBy: t => t.OrderByDescending(t => t.CreatedDate)
-            );
-
-            var transactionModels = _mapper.Map<Pagination<TransactionModel>>(transactions);
-            var result = PaginationHelper.GetPaginationResult(transactions, transactionModels);
-
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Message = MessageConstants.TRANSACTION_LIST_FETCHED_SUCCESS,
-                Data = result
-            };
-        }
-
-
         //admin
         public async Task<BaseResultModel> GetAllTransactionsForAdminAsync(PaginationParameter paginationParameter)
         {

--- a/MoneyEz.Services/Services/Interfaces/ITransactionService.cs
+++ b/MoneyEz.Services/Services/Interfaces/ITransactionService.cs
@@ -17,7 +17,5 @@ namespace MoneyEz.Services.Services.Interfaces
         Task<BaseResultModel> DeleteTransactionAsync(Guid transactionId);
         Task<BaseResultModel> GetAllTransactionsForAdminAsync(PaginationParameter paginationParameter);
         Task<BaseResultModel> GetTransactionByGroupIdAsync(PaginationParameter paginationParameter, TransactionFilter transactionFilter);
-        Task<BaseResultModel> GetTransactionsByUserSpendingModelAsync(PaginationParameter paginationParameter, Guid userSpendingModelId);
-
     }
 }

--- a/MoneyEz.Services/Services/Interfaces/IUserSpendingModelService.cs
+++ b/MoneyEz.Services/Services/Interfaces/IUserSpendingModelService.cs
@@ -15,5 +15,6 @@ namespace MoneyEz.Services.Services.Interfaces
         Task<BaseResultModel> GetUsedSpendingModelByIdAsync(Guid id);
         Task<BaseResultModel> GetUsedSpendingModelsPaginationAsync(PaginationParameter paginationParameter);
         Task<BaseResultModel> GetChartCurrentSpendingModelAsync();
+        Task<BaseResultModel> GetTransactionsByUserSpendingModelAsync(PaginationParameter paginationParameter, Guid userSpendingModelId);
     }
 }


### PR DESCRIPTION
This pull request includes changes to refactor the handling of transactions by user spending models in the `MoneyEz` application. The most important changes involve moving the responsibility for fetching transactions by user spending model from the `TransactionService` to the `UserSpendingModelService`.

Refactoring and code reorganization:

* Removed the `GetTransactionsByUserSpendingModelAsync` method from `TransactionService` (`MoneyEz.Services/Services/Implements/TransactionService.cs`).
* Added the `GetTransactionsByUserSpendingModelAsync` method to `UserSpendingModelService` (`MoneyEz.Services/Services/Implements/UserSpendingModelService.cs`).

Controller adjustments:

* Removed the `GetAllTransactionsBySpendingModel` endpoint from `TransactionsController` (`MoneyEz.API/Controllers/TransactionsController.cs`).
* Added the `GetAllTransactionsBySpendingModel` endpoint to `UserSpendingModelsController` (`MoneyEz.API/Controllers/UserSpendingModelsController.cs`).

Interface updates:

* Removed the `GetTransactionsByUserSpendingModelAsync` method from the `ITransactionService` interface (`MoneyEz.Services/Services/Interfaces/ITransactionService.cs`).
* Added the `GetTransactionsByUserSpendingModelAsync` method to the `IUserSpendingModelService` interface (`MoneyEz.Services/Services/Interfaces/IUserSpendingModelService.cs`).

Dependency adjustments:

* Added the necessary `using` statement for `TransactionModels` in `UserSpendingModelService` (`MoneyEz.Services/Services/Implements/UserSpendingModelService.cs`).
* Added the necessary `using` statement for `Implements` in `UserSpendingModelsController` (`MoneyEz.API/Controllers/UserSpendingModelsController.cs`).