### PR TITLE
fix(quiz): update quiz into NoSQL style for better flexibility

### DIFF
--- a/MoneyEz.API/Controllers/QuizController.cs
+++ b/MoneyEz.API/Controllers/QuizController.cs
@@ -23,7 +23,7 @@ namespace MoneyEz.API.Controllers
         [Authorize]
         public Task<IActionResult> GetAllQuizzes([FromQuery] PaginationParameter paginationParameter)
         {
-            return ValidateAndExecute(() => _quizService.GetQuizListAsync(paginationParameter));
+            return ValidateAndExecute(() => _quizService.GetAllQuizzesAsync(paginationParameter));
         }
 
         [HttpGet]
@@ -36,7 +36,7 @@ namespace MoneyEz.API.Controllers
 
         [HttpGet]
         [Route("active")]
-        //[Authorize]
+        [Authorize]
         public Task<IActionResult> GetActiveQuiz()
         {
             return ValidateAndExecute(() => _quizService.GetActiveQuizAsync());
@@ -51,17 +51,9 @@ namespace MoneyEz.API.Controllers
 
         [HttpPut]
         [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> UpdateQuiz(QuizModel model)
+        public Task<IActionResult> UpdateQuiz(UpdateQuizModel quizModel)
         {
-            return ValidateAndExecute(() => _quizService.UpdateQuizAsync(model));
-        }
-
-        [HttpDelete]
-        [Route("{id}")]
-        [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> DeleteQuiz([FromRoute] Guid id)
-        {
-            return ValidateAndExecute(() => _quizService.DeleteQuizAsync(id));
+            return ValidateAndExecute(() => _quizService.UpdateQuizAsync(quizModel));
         }
 
         [HttpPost]
@@ -69,71 +61,7 @@ namespace MoneyEz.API.Controllers
         [Authorize(Roles = "ADMIN")]
         public Task<IActionResult> SetActiveQuiz([FromRoute] Guid id)
         {
-            return ValidateAndExecute(() => _quizService.SetActiveQuizAsync(id));
-        }
-
-        #endregion
-
-        #region Quiz Questions Endpoints
-
-        [HttpGet]
-        [Route("{id}/questions")]
-        [Authorize]
-        public Task<IActionResult> GetQuestionsByQuizId([FromRoute] Guid id)
-        {
-            return ValidateAndExecute(() => _quizService.GetQuestionsByQuizIdAsync(id));
-        }
-
-        [HttpPost]
-        [Route("{id}/questions")]
-        [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> CreateQuestion([FromRoute] Guid id, CreateQuestionModel model)
-        {
-            return ValidateAndExecute(() => _quizService.CreateQuestionAsync(id, model));
-        }
-
-        [HttpPut]
-        [Route("questions")]
-        [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> UpdateQuestion(QuestionModel model)
-        {
-            return ValidateAndExecute(() => _quizService.UpdateQuestionAsync(model));
-        }
-
-        [HttpDelete]
-        [Route("questions/{questionId}")]
-        [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> DeleteQuestion([FromRoute] Guid questionId)
-        {
-            return ValidateAndExecute(() => _quizService.DeleteQuestionAsync(questionId));
-        }
-
-        #endregion
-
-        #region Answer Options Endpoints
-
-        [HttpPost]
-        [Route("questions/{questionId}/answer-options")]
-        [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> CreateAnswerOption([FromRoute] Guid questionId, CreateAnswerOptionModel model)
-        {
-            return ValidateAndExecute(() => _quizService.CreateAnswerOptionAsync(questionId, model));
-        }
-
-        [HttpPut]
-        [Route("answer-options")]
-        [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> UpdateAnswerOption(AnswerOptionModel model)
-        {
-            return ValidateAndExecute(() => _quizService.UpdateAnswerOptionAsync(model));
-        }
-
-        [HttpDelete]
-        [Route("answer-options/{answerOptionId}")]
-        [Authorize(Roles = "ADMIN")]
-        public Task<IActionResult> DeleteAnswerOption([FromRoute] Guid answerOptionId)
-        {
-            return ValidateAndExecute(() => _quizService.DeleteAnswerOptionAsync(answerOptionId));
+            return ValidateAndExecute(() => _quizService.ActivateQuizAsync(id));
         }
 
         #endregion
@@ -145,7 +73,7 @@ namespace MoneyEz.API.Controllers
         [Authorize]
         public Task<IActionResult> SubmitQuizAttempt(CreateQuizAttemptModel model)
         {
-            return ValidateAndExecute(() => _quizService.SubmitQuizAttemptAsync(model));
+            return ValidateAndExecute(() => _quizService.SubmitQuizAnswersAsync(model));
         }
 
         #endregion
@@ -157,23 +85,7 @@ namespace MoneyEz.API.Controllers
         [Authorize]
         public Task<IActionResult> GetAllUserQuizResults([FromQuery] PaginationParameter paginationParameter)
         {
-            return ValidateAndExecute(() => _quizService.GetAllUserQuizResultsAsync(paginationParameter));
-        }
-
-        [HttpGet]
-        [Route("user-quiz-results/{id}")]
-        [Authorize]
-        public Task<IActionResult> GetUserQuizResultById([FromRoute] Guid id)
-        {
-            return ValidateAndExecute(() => _quizService.GetUserQuizResultByIdAsync(id));
-        }
-
-        [HttpGet]
-        [Route("user-quiz-results/user")]
-        [Authorize]
-        public Task<IActionResult> GetUserQuizResultsByUserId([FromQuery] PaginationParameter paginationParameter)
-        {
-            return ValidateAndExecute(() => _quizService.GetUserQuizResultsByUserIdAsync(paginationParameter));
+            return ValidateAndExecute(() => _quizService.GetUserQuizHistoryAsync(paginationParameter));
         }
 
         #endregion

--- a/MoneyEz.Repositories/Entities/MoneyEzContext.cs
+++ b/MoneyEz.Repositories/Entities/MoneyEzContext.cs
@@ -62,12 +62,6 @@ public partial class MoneyEzContext : DbContext
 
     public virtual DbSet<BankAccount> BankAccounts { get; set; }
 
-    public virtual DbSet<AnswerOption> AnswerOptions { get; set; }
-
-    public virtual DbSet<Question> Questions { get; set; }
-
-    public virtual DbSet<UserQuizAnswer> UserQuizAnswers { get; set; }
-
     public virtual DbSet<UserQuizResult> UserQuizResults { get; set; }
 
     public virtual DbSet<Quiz> Quizzes { get; set; }
@@ -550,7 +544,7 @@ public partial class MoneyEzContext : DbContext
                 .IsRequired()
                 .HasMaxLength(100);
             entity.Property(e => e.WebhookSecretKey)
-                .HasMaxLength(60); 
+                .HasMaxLength(60);
             entity.Property(e => e.WebhookUrl)
                 .HasMaxLength(500);
 
@@ -570,35 +564,9 @@ public partial class MoneyEzContext : DbContext
             entity.Property(x => x.Id).ValueGeneratedOnAdd();
             entity.Property(e => e.Title);
             entity.Property(e => e.Description);
-        });
-
-        modelBuilder.Entity<Question>(entity =>
-        {
-            entity.HasKey(e => e.Id).HasName("PK__Question__3214EC07");
-
-            entity.ToTable("Question");
-
-            entity.Property(x => x.Id).ValueGeneratedOnAdd();
-            entity.Property(e => e.Content);
-
-            entity.HasOne(d => d.Quiz).WithMany(p => p.Questions)
-                .HasForeignKey(d => d.QuizId)
-                .HasConstraintName("FK__Question__QuizId");
-        });
-
-        modelBuilder.Entity<AnswerOption>(entity =>
-        {
-            entity.HasKey(e => e.Id).HasName("PK__AnswerOption__3214EC07");
-
-            entity.ToTable("AnswerOption");
-
-            entity.Property(x => x.Id).ValueGeneratedOnAdd();
-            entity.Property(e => e.Content);
-            entity.Property(e => e.Type).HasConversion<int>();
-
-            entity.HasOne(d => d.Question).WithMany(p => p.AnswerOptions)
-                .HasForeignKey(d => d.QuestionId)
-                .HasConstraintName("FK__AnswerOption__QuestionId");
+            entity.Property(e => e.QuestionsJson).HasColumnType("nvarchar(max)");
+            entity.Property(e => e.Version).HasMaxLength(20);
+            entity.Property(e => e.Status).HasConversion<int>();
         });
 
         modelBuilder.Entity<UserQuizResult>(entity =>
@@ -610,6 +578,8 @@ public partial class MoneyEzContext : DbContext
             entity.Property(x => x.Id).ValueGeneratedOnAdd();
             entity.Property(e => e.RecommendedModel);
             entity.Property(e => e.TakenAt);
+            entity.Property(e => e.QuizVersion).HasMaxLength(20);
+            entity.Property(e => e.AnswersJson).HasColumnType("nvarchar(max)");
 
             entity.HasOne(d => d.Quiz).WithMany(p => p.UserQuizResults)
                 .HasForeignKey(d => d.QuizId)
@@ -619,24 +589,6 @@ public partial class MoneyEzContext : DbContext
                 .HasForeignKey(d => d.UserId)
                 .OnDelete(DeleteBehavior.ClientSetNull)
                 .HasConstraintName("FK__UserQuizR__UserI__0C85DE4D");
-        });
-
-        modelBuilder.Entity<UserQuizAnswer>(entity =>
-        {
-            entity.HasKey(e => e.Id).HasName("PK__UserQuizAnswer__3214EC07");
-
-            entity.ToTable("UserQuizAnswer");
-
-            entity.Property(x => x.Id).ValueGeneratedOnAdd();
-            entity.Property(e => e.AnswerContent);
-
-            entity.HasOne(d => d.AnswerOption).WithMany(p => p.UserQuizAnswers)
-                .HasForeignKey(d => d.AnswerOptionId)
-                .HasConstraintName("FK__UserQuizAnswer__AnswerOptionId");
-
-            entity.HasOne(d => d.UserQuizResult).WithMany(p => p.UserQuizAnswers)
-                .HasForeignKey(d => d.UserQuizResultId)
-                .HasConstraintName("FK__UserQuizAnswer__UserQuizResultId");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/MoneyEz.Repositories/Entities/Quiz.cs
+++ b/MoneyEz.Repositories/Entities/Quiz.cs
@@ -2,6 +2,7 @@
 using MoneyEz.Repositories.Enums;
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace MoneyEz.Repositories.Entities;
 
@@ -13,7 +14,37 @@ public partial class Quiz : BaseEntity
 
     public CommonsStatus Status { get; set; }
 
-    public virtual ICollection<Question> Questions { get; set; } = new List<Question>();
+    public string QuestionsJson { get; set; } // Store questions and answers as JSON
+
+    public string Version { get; set; } // For tracking quiz versions
 
     public virtual ICollection<UserQuizResult> UserQuizResults { get; set; } = new List<UserQuizResult>();
+
+    // Helper methods for JSON serialization/deserialization
+    public void SetQuestions(List<QuizQuestion> questions)
+    {
+        QuestionsJson = JsonSerializer.Serialize(questions);
+    }
+
+    public List<QuizQuestion> GetQuestions()
+    {
+        if (string.IsNullOrEmpty(QuestionsJson))
+            return new List<QuizQuestion>();
+        
+        return JsonSerializer.Deserialize<List<QuizQuestion>>(QuestionsJson) ?? new List<QuizQuestion>();
+    }
+}
+
+// Inner classes for JSON serialization (not mapped to database)
+public class QuizQuestion
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Content { get; set; }
+    public List<QuizAnswerOption> AnswerOptions { get; set; } = new List<QuizAnswerOption>();
+}
+
+public class QuizAnswerOption
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Content { get; set; }
 }

--- a/MoneyEz.Repositories/Entities/UserQuizResult.cs
+++ b/MoneyEz.Repositories/Entities/UserQuizResult.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace MoneyEz.Repositories.Entities;
 
@@ -13,10 +14,35 @@ public partial class UserQuizResult : BaseEntity
     public string RecommendedModel { get; set; }
 
     public DateTime TakenAt { get; set; }
+    
+    public string QuizVersion { get; set; }
+    
+    public string AnswersJson { get; set; }
 
     public virtual Quiz Quiz { get; set; }
 
     public virtual User User { get; set; }
 
     public virtual ICollection<UserQuizAnswer> UserQuizAnswers { get; set; } = new List<UserQuizAnswer>();
+    
+    public void SetAnswers(List<UserAnswer> answers)
+    {
+        AnswersJson = JsonSerializer.Serialize(answers);
+    }
+
+    public List<UserAnswer> GetAnswers()
+    {
+        if (string.IsNullOrEmpty(AnswersJson))
+            return new List<UserAnswer>();
+        
+        return JsonSerializer.Deserialize<List<UserAnswer>>(AnswersJson) ?? new List<UserAnswer>();
+    }
+}
+
+// Inner class for JSON serialization (not mapped to database)
+public class UserAnswer
+{
+    public Guid QuestionId { get; set; }
+    public Guid? AnswerOptionId { get; set; }
+    public string AnswerContent { get; set; }
 }

--- a/MoneyEz.Repositories/Migrations/20250331204042_UpdateQuizIntoNoSQLStyle.Designer.cs
+++ b/MoneyEz.Repositories/Migrations/20250331204042_UpdateQuizIntoNoSQLStyle.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MoneyEz.Repositories.Entities;
 
@@ -11,9 +12,11 @@ using MoneyEz.Repositories.Entities;
 namespace MoneyEz.Repositories.Migrations
 {
     [DbContext(typeof(MoneyEzContext))]
-    partial class MoneyEzContextModelSnapshot : ModelSnapshot
+    [Migration("20250331204042_UpdateQuizIntoNoSQLStyle")]
+    partial class UpdateQuizIntoNoSQLStyle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MoneyEz.Repositories/Migrations/20250331204042_UpdateQuizIntoNoSQLStyle.cs
+++ b/MoneyEz.Repositories/Migrations/20250331204042_UpdateQuizIntoNoSQLStyle.cs
@@ -1,0 +1,295 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MoneyEz.Repositories.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateQuizIntoNoSQLStyle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK__AnswerOption__QuestionId",
+                table: "AnswerOption");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK__Question__QuizId",
+                table: "Question");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK__UserQuizAnswer__AnswerOptionId",
+                table: "UserQuizAnswer");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK__UserQuizAnswer__UserQuizResultId",
+                table: "UserQuizAnswer");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK__UserQuizAnswer__3214EC07",
+                table: "UserQuizAnswer");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK__Question__3214EC07",
+                table: "Question");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK__AnswerOption__3214EC07",
+                table: "AnswerOption");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AnswersJson",
+                table: "UserQuizResult",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "QuizVersion",
+                table: "UserQuizResult",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Type",
+                table: "RecurringTransaction",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Status",
+                table: "RecurringTransaction",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "StartDate",
+                table: "RecurringTransaction",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateOnly),
+                oldType: "date");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "FrequencyType",
+                table: "RecurringTransaction",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EndDate",
+                table: "RecurringTransaction",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "QuestionsJson",
+                table: "Quiz",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Version",
+                table: "Quiz",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_UserQuizAnswer",
+                table: "UserQuizAnswer",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Question",
+                table: "Question",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AnswerOption",
+                table: "AnswerOption",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AnswerOption_Question_QuestionId",
+                table: "AnswerOption",
+                column: "QuestionId",
+                principalTable: "Question",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Question_Quiz_QuizId",
+                table: "Question",
+                column: "QuizId",
+                principalTable: "Quiz",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserQuizAnswer_AnswerOption_AnswerOptionId",
+                table: "UserQuizAnswer",
+                column: "AnswerOptionId",
+                principalTable: "AnswerOption",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserQuizAnswer_UserQuizResult_UserQuizResultId",
+                table: "UserQuizAnswer",
+                column: "UserQuizResultId",
+                principalTable: "UserQuizResult",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AnswerOption_Question_QuestionId",
+                table: "AnswerOption");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Question_Quiz_QuizId",
+                table: "Question");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserQuizAnswer_AnswerOption_AnswerOptionId",
+                table: "UserQuizAnswer");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserQuizAnswer_UserQuizResult_UserQuizResultId",
+                table: "UserQuizAnswer");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_UserQuizAnswer",
+                table: "UserQuizAnswer");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Question",
+                table: "Question");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AnswerOption",
+                table: "AnswerOption");
+
+            migrationBuilder.DropColumn(
+                name: "AnswersJson",
+                table: "UserQuizResult");
+
+            migrationBuilder.DropColumn(
+                name: "QuizVersion",
+                table: "UserQuizResult");
+
+            migrationBuilder.DropColumn(
+                name: "QuestionsJson",
+                table: "Quiz");
+
+            migrationBuilder.DropColumn(
+                name: "Version",
+                table: "Quiz");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Type",
+                table: "RecurringTransaction",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Status",
+                table: "RecurringTransaction",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "StartDate",
+                table: "RecurringTransaction",
+                type: "date",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "FrequencyType",
+                table: "RecurringTransaction",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "EndDate",
+                table: "RecurringTransaction",
+                type: "date",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK__UserQuizAnswer__3214EC07",
+                table: "UserQuizAnswer",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK__Question__3214EC07",
+                table: "Question",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK__AnswerOption__3214EC07",
+                table: "AnswerOption",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK__AnswerOption__QuestionId",
+                table: "AnswerOption",
+                column: "QuestionId",
+                principalTable: "Question",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK__Question__QuizId",
+                table: "Question",
+                column: "QuizId",
+                principalTable: "Quiz",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK__UserQuizAnswer__AnswerOptionId",
+                table: "UserQuizAnswer",
+                column: "AnswerOptionId",
+                principalTable: "AnswerOption",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK__UserQuizAnswer__UserQuizResultId",
+                table: "UserQuizAnswer",
+                column: "UserQuizResultId",
+                principalTable: "UserQuizResult",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/MoneyEz.Repositories/Repositories/Implements/QuizRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Implements/QuizRepository.cs
@@ -1,62 +1,77 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using MoneyEz.Repositories.Commons;
 using MoneyEz.Repositories.Entities;
-using MoneyEz.Repositories.Enums;
 using MoneyEz.Repositories.Repositories.Interfaces;
+using System.Text.Json;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace MoneyEz.Repositories.Repositories.Implements
 {
     public class QuizRepository : GenericRepository<Quiz>, IQuizRepository
     {
-        private readonly MoneyEzContext _context;
-
+        private readonly MoneyEzContext _dbContext;
+        
         public QuizRepository(MoneyEzContext context) : base(context)
         {
-            _context = context;
+            _dbContext = context;
+        }
+        
+        public async Task<Quiz> GetQuizByIdAsync(Guid id)
+        {
+            return await _dbContext.Quizzes.FindAsync(id);
         }
 
-        public async Task<Pagination<Quiz>> GetAllAsyncPagingInclude(PaginationParameter paginationParameter)
+        public async Task<Quiz> GetActiveQuizAsync()
         {
-            var quizzes = await ToPaginationIncludeAsync(
-                paginationParameter,
-                include: q => q.Include(x => x.Questions)
-                    .ThenInclude(q => q.AnswerOptions));
-
-            return quizzes ?? new Pagination<Quiz>();
+            return await _dbContext.Quizzes
+                .Where(q => q.Status == Enums.CommonsStatus.ACTIVE)
+                .FirstOrDefaultAsync();
+        }
+        
+        public async Task<Quiz> CreateQuizVersionAsync(Quiz quiz)
+        {
+            quiz.Version = DateTime.Now.ToString("yyyyMMddHHmm");
+            
+            await _dbContext.Quizzes.AddAsync(quiz);
+            await _dbContext.SaveChangesAsync();
+            
+            return quiz;
+        }
+        
+        public async Task<Quiz> UpdateQuizAsync(Quiz quiz)
+        {
+            // Preserve original ID but create a new version
+            var existingQuiz = await _dbContext.Quizzes.FindAsync(quiz.Id);
+            if (existingQuiz == null)
+                return null;
+                
+            // Update the version
+            quiz.Version = DateTime.Now.ToString("yyyyMMddHHmm");
+            
+            // Update the values
+            _dbContext.Entry(existingQuiz).CurrentValues.SetValues(quiz);
+            await _dbContext.SaveChangesAsync();
+            
+            return existingQuiz;
         }
 
-        public async Task<Quiz?> GetByIdAsyncInclude(Guid id)
+        public async Task<Pagination<Quiz>> GetAllQuizzesPaginatedAsync(PaginationParameter paginationParameter)
         {
-            return await _context.Set<Quiz>()
-                .Include(q => q.Questions)
-                .ThenInclude(q => q.AnswerOptions)
-                .FirstOrDefaultAsync(q => q.Id == id && !q.IsDeleted);
-        }
+            var quizzes = _dbContext.Quizzes
+                .OrderByDescending(q => q.CreatedDate)
+                .AsQueryable();
 
-        public async Task<Quiz?> GetActiveQuizAsync()
-        {
-            return await _context.Set<Quiz>()
-                .Include(q => q.Questions)
-                .ThenInclude(q => q.AnswerOptions)
-                .FirstOrDefaultAsync(q => q.Status == CommonsStatus.ACTIVE && !q.IsDeleted);
-        }
-
-        public async Task DeactivateAllQuizzesAsync()
-        {
-            var activeQuizzes = await _context.Set<Quiz>()
-                .Where(q => q.Status == CommonsStatus.ACTIVE && !q.IsDeleted)
+            var count = await quizzes.CountAsync();
+            var items = await quizzes
+                .Skip((paginationParameter.PageIndex - 1) * paginationParameter.PageSize)
+                .Take(paginationParameter.PageSize)
                 .ToListAsync();
 
-            foreach (var quiz in activeQuizzes)
-            {
-                quiz.Status = CommonsStatus.INACTIVE;
-                _context.Set<Quiz>().Update(quiz);
-            }
-
-            await _context.SaveChangesAsync();
+            return new Pagination<Quiz>(items, count, paginationParameter.PageIndex, paginationParameter.PageSize);
         }
     }
 }

--- a/MoneyEz.Repositories/Repositories/Implements/UserQuizResultRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Implements/UserQuizResultRepository.cs
@@ -12,61 +12,60 @@ namespace MoneyEz.Repositories.Repositories.Implements
 {
     public class UserQuizResultRepository : GenericRepository<UserQuizResult>, IUserQuizResultRepository
     {
-        private readonly MoneyEzContext _context;
+        private readonly MoneyEzContext _dbContext;
 
         public UserQuizResultRepository(MoneyEzContext context) : base(context)
         {
-            _context = context;
+            _dbContext = context;
         }
-        public async Task<Pagination<UserQuizResult>> GetAllUserQuizResultsAsync(PaginationParameter paginationParameter)
+
+        public async Task<UserQuizResult> GetUserQuizResultByIdAsync(Guid id)
         {
-            var query = _context.Set<UserQuizResult>()
+            return await _dbContext.UserQuizResults
                 .Include(uqr => uqr.Quiz)
-                .Include(uqr => uqr.User)
-                .Include(uqr => uqr.UserQuizAnswers)
-                .AsQueryable();
-
-            query = query.OrderBy(uqr => uqr.TakenAt);
-
-            var itemCount = await query.CountAsync();
-            var items = await query.Skip((paginationParameter.PageIndex - 1) * paginationParameter.PageSize)
-                                   .Take(paginationParameter.PageSize)
-                                   .AsNoTracking()
-                                   .ToListAsync();
-
-            var result = new Pagination<UserQuizResult>(items, itemCount, paginationParameter.PageIndex, paginationParameter.PageSize);
-            return result;
+                .FirstOrDefaultAsync(uqr => uqr.Id == id);
         }
-        public async Task<UserQuizResult?> GetUserQuizResultByIdAsync(Guid id)
-        {
-            var query = _context.Set<UserQuizResult>()
-                .Include(uqr => uqr.Quiz)
-                .Include(uqr => uqr.User)
-                .Include(uqr => uqr.UserQuizAnswers)
-                .AsQueryable();
 
-            var userQuizResult = await query.AsNoTracking().FirstOrDefaultAsync(uqr => uqr.Id == id);
-            return userQuizResult;
-        }
-        public async Task<Pagination<UserQuizResult>> GetUserQuizResultsByUserIdAsync(Guid userId, PaginationParameter paginationParameter)
+        public async Task<List<UserQuizResult>> GetUserQuizResultsByUserIdAsync(Guid userId)
         {
-            var query = _context.Set<UserQuizResult>()
+            return await _dbContext.UserQuizResults
                 .Include(uqr => uqr.Quiz)
-                .Include(uqr => uqr.User)
-                .Include(uqr => uqr.UserQuizAnswers)
                 .Where(uqr => uqr.UserId == userId)
+                .OrderByDescending(uqr => uqr.TakenAt)
+                .ToListAsync();
+        }
+
+        public async Task<Pagination<UserQuizResult>> GetUserQuizResultsByUserIdPaginatedAsync(Guid userId, PaginationParameter paginationParameter)
+        {
+            var query = _dbContext.UserQuizResults
+                .Include(uqr => uqr.Quiz)
+                .Where(uqr => uqr.UserId == userId)
+                .OrderByDescending(uqr => uqr.TakenAt)
                 .AsQueryable();
 
-            query = query.OrderBy(uqr => uqr.TakenAt);
+            var count = await query.CountAsync();
+            var items = await query
+                .Skip((paginationParameter.PageIndex - 1) * paginationParameter.PageSize)
+                .Take(paginationParameter.PageSize)
+                .ToListAsync();
 
-            var itemCount = await query.CountAsync();
-            var items = await query.Skip((paginationParameter.PageIndex - 1) * paginationParameter.PageSize)
-                                   .Take(paginationParameter.PageSize)
-                                   .AsNoTracking()
-                                   .ToListAsync();
+            return new Pagination<UserQuizResult>(items, count, paginationParameter.PageIndex, paginationParameter.PageSize);
+        }
 
-            var result = new Pagination<UserQuizResult>(items, itemCount, paginationParameter.PageIndex, paginationParameter.PageSize);
-            return result;
+        public async Task<UserQuizResult> CreateUserQuizResultAsync(UserQuizResult userQuizResult)
+        {
+            var quiz = await _dbContext.Quizzes.FindAsync(userQuizResult.QuizId);
+            if (quiz != null)
+            {
+                userQuizResult.QuizVersion = quiz.Version;
+            }
+            
+            userQuizResult.TakenAt = DateTime.Now;
+            
+            await _dbContext.UserQuizResults.AddAsync(userQuizResult);
+            await _dbContext.SaveChangesAsync();
+            
+            return userQuizResult;
         }
     }
 }

--- a/MoneyEz.Repositories/Repositories/Interfaces/IQuizRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Interfaces/IQuizRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using MoneyEz.Repositories.Commons;
 using MoneyEz.Repositories.Entities;
@@ -9,9 +10,10 @@ namespace MoneyEz.Repositories.Repositories.Interfaces
 {
     public interface IQuizRepository : IGenericRepository<Quiz>
     {
-        Task<Pagination<Quiz>> GetAllAsyncPagingInclude(PaginationParameter paginationParameter);
-        Task<Quiz?> GetByIdAsyncInclude(Guid id);
-        Task<Quiz?> GetActiveQuizAsync();
-        Task DeactivateAllQuizzesAsync();
+        Task<Quiz> GetQuizByIdAsync(Guid id);
+        Task<Quiz> GetActiveQuizAsync();
+        Task<Quiz> CreateQuizVersionAsync(Quiz quiz);
+        Task<Quiz> UpdateQuizAsync(Quiz quiz);
+        Task<Pagination<Quiz>> GetAllQuizzesPaginatedAsync(PaginationParameter paginationParameter);
     }
 }

--- a/MoneyEz.Repositories/Repositories/Interfaces/IUserQuizResultRepository.cs
+++ b/MoneyEz.Repositories/Repositories/Interfaces/IUserQuizResultRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using MoneyEz.Repositories.Commons;
 using MoneyEz.Repositories.Entities;
@@ -9,8 +10,9 @@ namespace MoneyEz.Repositories.Repositories.Interfaces
 {
     public interface IUserQuizResultRepository : IGenericRepository<UserQuizResult>
     {
-        Task<Pagination<UserQuizResult>> GetAllUserQuizResultsAsync(PaginationParameter paginationParameter);
-        Task<UserQuizResult?> GetUserQuizResultByIdAsync(Guid id);
-        Task<Pagination<UserQuizResult>> GetUserQuizResultsByUserIdAsync(Guid userId, PaginationParameter paginationParameter);
+        Task<UserQuizResult> GetUserQuizResultByIdAsync(Guid id);
+        Task<List<UserQuizResult>> GetUserQuizResultsByUserIdAsync(Guid userId);
+        Task<Pagination<UserQuizResult>> GetUserQuizResultsByUserIdPaginatedAsync(Guid userId, PaginationParameter paginationParameter);
+        Task<UserQuizResult> CreateUserQuizResultAsync(UserQuizResult userQuizResult);
     }
 }

--- a/MoneyEz.Services/BusinessModels/QuizModels/QuizAttemptModel.cs
+++ b/MoneyEz.Services/BusinessModels/QuizModels/QuizAttemptModel.cs
@@ -1,6 +1,7 @@
 ﻿using MoneyEz.Repositories.Entities;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,13 +10,28 @@ namespace MoneyEz.Services.BusinessModels.QuizModels
 {
     public class CreateQuizAttemptModel
     {
+        [Required(ErrorMessage = "Quiz ID không được để trống")]
         public Guid QuizId { get; set; }
-        public List<CreateUserQuizAnswerModel> Answers { get; set; } = new();
+
+        [Required(ErrorMessage = "Câu trả lời không được để trống")]
+        public List<UserAnswerModel> Answers { get; set; } = new();
     }
+    
+    public class UserAnswerModel
+    {
+        public Guid? QuestionId { get; set; }
+        
+        public Guid? AnswerOptionId { get; set; }
+        
+        [Required(ErrorMessage = "Nội dung câu trả lời không được để trống")]
+        public string AnswerContent { get; set; }
+    }
+    
     public class QuizAttemptModel
     {
         public Guid Id { get; set; }
         public Guid QuizId { get; set; }
-        public List<UserQuizAnswerModel> Answers { get; set; } = new();
+        public string QuizVersion { get; set; }
+        public List<UserAnswerModel> Answers { get; set; } = new();
     }
 }

--- a/MoneyEz.Services/BusinessModels/QuizModels/QuizModel.cs
+++ b/MoneyEz.Services/BusinessModels/QuizModels/QuizModel.cs
@@ -19,12 +19,18 @@ namespace MoneyEz.Services.BusinessModels.QuizModels
 
         public CommonsStatus Status { get; set; } = CommonsStatus.INACTIVE;
 
-        public List<CreateQuestionModel> Questions { get; set; } = new();
+        public string Version { get; set; } = "1.0";
+
+        public List<QuizQuestionModel> Questions { get; set; } = new();
     }
 
-    public class QuizModel
+    public class UpdateQuizModel : CreateQuizModel
     {
         public Guid Id { get; set; }
+    }
+
+    public class QuizModel : BaseEntity
+    {
         [Required(ErrorMessage = "Tiêu đề bộ quiz không được để trống")]
         public string Title { get; set; }
 
@@ -32,7 +38,26 @@ namespace MoneyEz.Services.BusinessModels.QuizModels
         public string Description { get; set; }
 
         public CommonsStatus Status { get; set; }
+        
+        public string Version { get; set; }
 
-        public List<QuestionModel> Questions { get; set; } = new List<QuestionModel>();
+        public List<QuizQuestionModel> Questions { get; set; } = new();
+    }
+
+    public class QuizQuestionModel
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        
+        [Required(ErrorMessage = "Nội dung câu hỏi không được để trống")]
+        public string Content { get; set; }
+        
+        [MinLength(2, ErrorMessage = "Phải có ít nhất 2 câu trả lời cho câu hỏi")]
+        public List<QuizAnswerOptionModel> AnswerOptions { get; set; } = new();
+    }
+
+    public class QuizAnswerOptionModel
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Content { get; set; }
     }
 }

--- a/MoneyEz.Services/BusinessModels/QuizModels/UserQuizResultModel.cs
+++ b/MoneyEz.Services/BusinessModels/QuizModels/UserQuizResultModel.cs
@@ -22,15 +22,11 @@ namespace MoneyEz.Services.BusinessModels.QuizModels
     public class UserQuizResultModel
     {
         public Guid Id { get; set; }
-
-        [Required(ErrorMessage = "User ID không được để trống")]
         public Guid UserId { get; set; }
-
-        [Required(ErrorMessage = "Quiz ID không được để trống")]
         public Guid QuizId { get; set; }
-
+        public string QuizVersion { get; set; }
+        public DateTime TakenAt { get; set; }
         public string RecommendedModel { get; set; }
-
-        public List<UserQuizAnswerModel> UserAnswers { get; set; } = new List<UserQuizAnswerModel>();
+        public List<UserAnswerModel> Answers { get; set; } = new List<UserAnswerModel>();
     }
 }

--- a/MoneyEz.Services/Mappers/QuizMapperConfig.cs
+++ b/MoneyEz.Services/Mappers/QuizMapperConfig.cs
@@ -13,31 +13,94 @@ namespace MoneyEz.Services.Mappers
     {
         public QuizMapperConfig()
         {
+            // Quiz mappings
             CreateMap<CreateQuizModel, Quiz>()
-                .ForMember(dest => dest.Questions, opt => opt.Ignore());
+                .ForMember(dest => dest.QuestionsJson, opt => opt.Ignore())
+                .AfterMap((src, dest) =>
+                {
+                    // Convert Questions to JSON format
+                    var quizQuestions = src.Questions.Select(q => new QuizQuestion
+                    {
+                        Id = q.Id,
+                        Content = q.Content,
+                        AnswerOptions = q.AnswerOptions.Select(a => new QuizAnswerOption
+                        {
+                            Id = a.Id,
+                            Content = a.Content
+                        }).ToList()
+                    }).ToList();
 
-            CreateMap<CreateQuestionModel, Question>()
-                .ForMember(dest => dest.AnswerOptions, opt => opt.Ignore());
+                    dest.SetQuestions(quizQuestions);
+                });
 
-            CreateMap<CreateAnswerOptionModel, AnswerOption>();
+            CreateMap<UpdateQuizModel, Quiz>()
+                .ForMember(dest => dest.QuestionsJson, opt => opt.Ignore())
+                .AfterMap((src, dest) =>
+                {
+                    // Convert Questions to JSON format
+                    var quizQuestions = src.Questions.Select(q => new QuizQuestion
+                    {
+                        Id = q.Id,
+                        Content = q.Content,
+                        AnswerOptions = q.AnswerOptions.Select(a => new QuizAnswerOption
+                        {
+                            Id = a.Id,
+                            Content = a.Content
+                        }).ToList()
+                    }).ToList();
 
-            CreateMap<CreateUserQuizAnswerModel, UserQuizAnswer>();
+                    dest.SetQuestions(quizQuestions);
+                });
 
             CreateMap<Quiz, QuizModel>()
-                .ForMember(dest => dest.Questions, opt => opt.MapFrom(src => src.Questions));
+                .ForMember(dest => dest.Questions, opt => opt.MapFrom(src => src.GetQuestions()
+                    .Select(q => new QuizQuestionModel
+                    {
+                        Id = q.Id,
+                        Content = q.Content,
+                        AnswerOptions = q.AnswerOptions.Select(a => new QuizAnswerOptionModel
+                        {
+                            Id = a.Id,
+                            Content = a.Content
+                        }).ToList()
+                    }).ToList()));
 
-            CreateMap<Question, QuestionModel>()
-                .ForMember(dest => dest.AnswerOptions, opt => opt.MapFrom(src => src.AnswerOptions));
 
-            CreateMap<AnswerOption, AnswerOptionModel>();
+            // User quiz result mappings
+            CreateMap<CreateQuizAttemptModel, UserQuizResult>()
+                .ForMember(dest => dest.AnswersJson, opt => opt.Ignore())
+                .AfterMap((src, dest) =>
+                {
+                    var answers = src.Answers.Select(a => new UserAnswer
+                    {
+                        QuestionId = a.QuestionId ?? Guid.Empty,
+                        AnswerOptionId = a.AnswerOptionId,
+                        AnswerContent = a.AnswerContent
+                    }).ToList();
 
-            CreateMap<UserQuizAnswer, UserQuizAnswerModel>();
+                    dest.SetAnswers(answers);
+                });
 
+            CreateMap<UserQuizResult, QuizAttemptModel>()
+                .ForMember(dest => dest.Answers, opt => opt.MapFrom(src =>
+                    src.GetAnswers().Select(a => new UserAnswerModel
+                    {
+                        QuestionId = a.QuestionId == Guid.Empty ? null : a.QuestionId,
+                        AnswerOptionId = a.AnswerOptionId,
+                        AnswerContent = a.AnswerContent
+                    }).ToList()
+                 ));
+
+            // Add mapping for UserQuizResult to UserQuizResultModel
             CreateMap<UserQuizResult, UserQuizResultModel>()
-                .ForMember(dest => dest.UserAnswers, opt => opt.MapFrom(src => src.UserQuizAnswers));
-
-            CreateMap<CreateUserQuizResultModel, UserQuizResult>()
-                .ForMember(dest => dest.UserQuizAnswers, opt => opt.MapFrom(src => src.UserQuizAnswers));
+                .ForMember(dest => dest.Answers, opt => opt.MapFrom(src =>
+                    src.GetAnswers().Select(a => new UserAnswerModel
+                    {
+                        QuestionId = a.QuestionId == Guid.Empty ? null : a.QuestionId,
+                        AnswerOptionId = a.AnswerOptionId,
+                        AnswerContent = a.AnswerContent
+                    }).ToList()
+                ));
         }
     }
 }

--- a/MoneyEz.Services/Services/Implements/QuizService.cs
+++ b/MoneyEz.Services/Services/Implements/QuizService.cs
@@ -1,15 +1,21 @@
-﻿// C#
-using AutoMapper;
+﻿using AutoMapper;
 using Microsoft.AspNetCore.Http;
 using MoneyEz.Repositories.Commons;
 using MoneyEz.Repositories.Entities;
 using MoneyEz.Repositories.Enums;
+using MoneyEz.Repositories.Repositories.Interfaces;
 using MoneyEz.Repositories.UnitOfWork;
 using MoneyEz.Repositories.Utils;
 using MoneyEz.Services.BusinessModels.QuizModels;
 using MoneyEz.Services.BusinessModels.ResultModels;
+using MoneyEz.Services.Constants;
 using MoneyEz.Services.Exceptions;
 using MoneyEz.Services.Services.Interfaces;
+using MoneyEz.Services.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace MoneyEz.Services.Services.Implements
 {
@@ -26,435 +32,236 @@ namespace MoneyEz.Services.Services.Implements
             _claimsService = claimsService;
         }
 
+        // ADMIN FUNCTIONS
+
         public async Task<BaseResultModel> CreateQuizAsync(CreateQuizModel createQuizModel)
         {
-            if (createQuizModel == null)
-            {
-                throw new ArgumentException("Quiz model is null.", nameof(createQuizModel));
-            }
-            if (string.IsNullOrWhiteSpace(createQuizModel.Title))
-            {
-                throw new ArgumentException("Quiz title is required.", nameof(createQuizModel.Title));
-            }
-
             var quiz = _mapper.Map<Quiz>(createQuizModel);
             
-            // If the new quiz should be active, deactivate all other quizzes first
-            if (quiz.Status == CommonsStatus.ACTIVE)
-            {
-                await _unitOfWork.QuizRepository.DeactivateAllQuizzesAsync();
-            }
+            // Create a new quiz with versioning
+            var createdQuiz = await _unitOfWork.QuizRepository.CreateQuizVersionAsync(quiz);
             
-            await _unitOfWork.QuizRepository.AddAsync(quiz);
-
-            foreach (var createQuestionModel in createQuizModel.Questions)
-            {
-                var question = _mapper.Map<Question>(createQuestionModel);
-                question.QuizId = quiz.Id;
-                await _unitOfWork.QuestionRepository.AddAsync(question);
-
-                foreach (var createAnswerOptionModel in createQuestionModel.AnswerOptions)
-                {
-                    var answerOption = _mapper.Map<AnswerOption>(createAnswerOptionModel);
-                    answerOption.QuestionId = question.Id;
-                    await _unitOfWork.AnswerOptionRepository.AddAsync(answerOption);
-                }
-            }
-
-            await _unitOfWork.SaveAsync();
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status201Created,
-                Data = _mapper.Map<QuizModel>(quiz),
-                Message = "Quiz created successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> SubmitQuizAttemptAsync(CreateQuizAttemptModel quizAttemptModel)
-        {
-            if (quizAttemptModel == null || quizAttemptModel.QuizId == Guid.Empty)
-            {
-                throw new ArgumentException("Quiz attempt model or QuizId is invalid.");
-            }
-
-            var quiz = await _unitOfWork.QuizRepository.GetByIdAsync(quizAttemptModel.QuizId);
-            if (quiz == null)
-            {
-                throw new NotExistException("", "Quiz not found.");
-            }
-
-            var user = await _unitOfWork.UsersRepository.GetUserByEmailAsync(_claimsService.GetCurrentUserEmail);
-            if (user == null)
-            {
-                throw new NotExistException("", "User not found.");
-            }
-
-            var quizResult = new UserQuizResult
-            {
-                UserId = user.Id,
-                QuizId = quizAttemptModel.QuizId,
-                TakenAt = CommonUtils.GetCurrentTime(),
-                RecommendedModel = "50-30-20" // TODO: goi AI
-            };
-
-            await _unitOfWork.UserQuizResultRepository.AddAsync(quizResult);
-            await _unitOfWork.SaveAsync();
-
-            var answers = _mapper.Map<List<UserQuizAnswer>>(quizAttemptModel.Answers);
-            foreach (var answer in answers)
-            {
-                answer.UserQuizResultId = quizResult.Id;
-                await _unitOfWork.UserQuizAnswerRepository.AddAsync(answer);
-            }
-            await _unitOfWork.SaveAsync();
-
             return new BaseResultModel
             {
                 Status = StatusCodes.Status200OK,
-                Data = _mapper.Map<UserQuizResultModel>(quizResult),
-                Message = "Quiz attempt submitted successfully."
+                Data = _mapper.Map<QuizModel>(createdQuiz),
+                Message = "Tạo bộ câu hỏi thành công"
             };
         }
 
-        public async Task<BaseResultModel> GetQuizByIdAsync(Guid quizId)
+        public async Task<BaseResultModel> GetQuizByIdAsync(Guid id)
         {
-            if (quizId == Guid.Empty)
-            {
-                throw new ArgumentException("QuizId is invalid.", nameof(quizId));
-            }
-            var quiz = await _unitOfWork.QuizRepository.GetByIdAsyncInclude(quizId);
+            var quiz = await _unitOfWork.QuizRepository.GetQuizByIdAsync(id);
             if (quiz == null)
-            {
-                throw new NotExistException("", "Quiz not found.");
-            }
+                throw new NotExistException($"Không tìm thấy bộ câu hỏi với ID: {id}");
+            
             return new BaseResultModel
             {
                 Status = StatusCodes.Status200OK,
                 Data = _mapper.Map<QuizModel>(quiz),
-                Message = "Quiz retrieved successfully."
+                Message = "Lấy bộ câu hỏi thành công"
             };
         }
 
-        public async Task<BaseResultModel> GetQuizListAsync(PaginationParameter paginationParameter)
+        public async Task<BaseResultModel> GetAllQuizzesAsync(PaginationParameter paginationParameter)
         {
-            var pagedQuizzes = await _unitOfWork.QuizRepository.GetAllAsyncPagingInclude(paginationParameter);
-            var resultData = _mapper.Map<Pagination<QuizModel>>(pagedQuizzes);
-            return new BaseResultModel
+            var quizzesPagination = await _unitOfWork.QuizRepository.GetAllQuizzesPaginatedAsync(paginationParameter);
+            var quizModels = _mapper.Map<List<QuizModel>>(quizzesPagination);
+            
+            // Create pagination metadata
+            var metadata = new
             {
-                Status = StatusCodes.Status200OK,
-                Data = resultData,
-                Message = "Quiz list retrieved successfully."
+                quizzesPagination.TotalCount,
+                quizzesPagination.PageSize,
+                quizzesPagination.CurrentPage,
+                quizzesPagination.TotalPages,
+                quizzesPagination.HasNext,
+                quizzesPagination.HasPrevious
             };
-        }
-
-        public async Task<BaseResultModel> UpdateQuizAsync(QuizModel quizModel)
-        {
-            if (quizModel == null || quizModel.Id == Guid.Empty)
-            {
-                throw new ArgumentException("Quiz model is null or invalid.", nameof(quizModel));
-            }
-            var quiz = await _unitOfWork.QuizRepository.GetByIdAsync(quizModel.Id);
-            if (quiz == null)
-            {
-                throw new NotExistException("", "Quiz not found.");
-            }
-            
-            bool activationChanged = quiz.Status != quizModel.Status && quizModel.Status == CommonsStatus.ACTIVE;
-            
-            _mapper.Map(quizModel, quiz);
-            
-            if (activationChanged)
-            {
-                await _unitOfWork.QuizRepository.DeactivateAllQuizzesAsync();
-                quiz.Status = CommonsStatus.ACTIVE; 
-            }
-            
-            _unitOfWork.QuizRepository.UpdateAsync(quiz);
-            await _unitOfWork.SaveAsync();
             
             return new BaseResultModel
             {
                 Status = StatusCodes.Status200OK,
-                Message = "Quiz updated successfully."
+                Data = PaginationHelper.GetPaginationResult(quizzesPagination, quizModels),
+                Message = "Lấy tất cả bộ câu hỏi thành công"
             };
         }
 
-        public async Task<BaseResultModel> DeleteQuizAsync(Guid quizId)
+        public async Task<BaseResultModel> UpdateQuizAsync(UpdateQuizModel quizModel)
         {
-            if (quizId == Guid.Empty)
-            {
-                throw new ArgumentException("QuizId is invalid.", nameof(quizId));
-            }
-            var quiz = await _unitOfWork.QuizRepository.GetByIdAsync(quizId);
-            if (quiz == null)
-            {
-                throw new NotExistException("", "Quiz not found.");
-            }
-            _unitOfWork.QuizRepository.SoftDeleteAsync(quiz);
-            await _unitOfWork.SaveAsync();
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Message = "Quiz deleted successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> GetQuestionsByQuizIdAsync(Guid quizId)
-        {
-            if (quizId == Guid.Empty)
-            {
-                throw new ArgumentException("QuizId is invalid.", nameof(quizId));
-            }
-            var questions = await _unitOfWork.QuestionRepository.GetByQuizIdAsync(quizId);
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Data = _mapper.Map<List<QuestionModel>>(questions),
-                Message = "Questions retrieved successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> CreateQuestionAsync(Guid quizId, CreateQuestionModel questionModel)
-        {
-            if (quizId == Guid.Empty)
-            {
-                throw new ArgumentException("QuizId is invalid.", nameof(quizId));
-            }
-            if (questionModel == null)
-            {
-                throw new ArgumentException("Question model is null.", nameof(questionModel));
-            }
-            if (string.IsNullOrWhiteSpace(questionModel.Content))
-            {
-                throw new ArgumentException("Question content is required.", nameof(questionModel.Content));
-            }
-
-            var quiz = await _unitOfWork.QuizRepository.GetByIdAsync(quizId);
-            if (quiz == null)
-            {
-                throw new NotExistException("", "Quiz not found.");
-            }
-
-            var question = _mapper.Map<Question>(questionModel);
-            question.QuizId = quizId;
-            await _unitOfWork.QuestionRepository.AddAsync(question);
-            await _unitOfWork.SaveAsync();
-
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status201Created,
-                Data = _mapper.Map<QuestionModel>(question),
-                Message = "Question created successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> UpdateQuestionAsync(QuestionModel questionModel)
-        {
-            if (questionModel.Id == Guid.Empty)
-            {
-                throw new ArgumentException("QuestionId is invalid.", nameof(questionModel.Id));
-            }
-            if (questionModel == null)
-            {
-                throw new ArgumentException("Question model is null.", nameof(questionModel));
-            }
-            var question = await _unitOfWork.QuestionRepository.GetByIdAsync(questionModel.Id);
-            if (question == null)
-            {
-                throw new NotExistException("", "Question not found.");
-            }
-            _mapper.Map(questionModel, question);
-            _unitOfWork.QuestionRepository.UpdateAsync(question);
-            await _unitOfWork.SaveAsync();
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Message = "Question updated successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> DeleteQuestionAsync(Guid questionId)
-        {
-            if (questionId == Guid.Empty)
-            {
-                throw new ArgumentException("QuestionId is invalid.", nameof(questionId));
-            }
-            var question = await _unitOfWork.QuestionRepository.GetByIdAsync(questionId);
-            if (question == null)
-            {
-                throw new NotExistException("", "Question not found.");
-            }
-            _unitOfWork.QuestionRepository.SoftDeleteAsync(question);
-            await _unitOfWork.SaveAsync();
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Message = "Question deleted successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> CreateAnswerOptionAsync(Guid questionId, CreateAnswerOptionModel answerOptionModel)
-        {
-            if (questionId == Guid.Empty)
-            {
-                throw new ArgumentException("QuestionId is invalid.", nameof(questionId));
-            }
-            if (answerOptionModel == null)
-            {
-                throw new ArgumentException("Answer option model is null.", nameof(answerOptionModel));
-            }
-            if (string.IsNullOrWhiteSpace(answerOptionModel.Content))
-            {
-                throw new ArgumentException("Answer option content is required.", nameof(answerOptionModel.Content));
-            }
-
-            var question = await _unitOfWork.QuestionRepository.GetByIdAsync(questionId);
-            if (question == null)
-            {
-                throw new NotExistException("", "Question not found.");
-            }
-
-            var answerOption = _mapper.Map<AnswerOption>(answerOptionModel);
-            answerOption.QuestionId = questionId;
-            await _unitOfWork.AnswerOptionRepository.AddAsync(answerOption);
-            await _unitOfWork.SaveAsync();
-
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status201Created,
-                Data = _mapper.Map<AnswerOptionModel>(answerOption),
-                Message = "Answer option created successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> UpdateAnswerOptionAsync(AnswerOptionModel answerOptionModel)
-        {
-            if (answerOptionModel.Id == Guid.Empty)
-            {
-                throw new ArgumentException("AnswerOptionId is invalid.", nameof(answerOptionModel.Id));
-            }
-            if (answerOptionModel == null)
-            {
-                throw new ArgumentException("Answer option model is null.", nameof(answerOptionModel));
-            }
-            var answerOption = await _unitOfWork.AnswerOptionRepository.GetByIdAsync(answerOptionModel.Id);
-            if (answerOption == null)
-            {
-                throw new NotExistException("", "Answer option not found.");
-            }
-            _mapper.Map(answerOptionModel, answerOption);
-            _unitOfWork.AnswerOptionRepository.UpdateAsync(answerOption);
-            await _unitOfWork.SaveAsync();
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Message = "Answer option updated successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> DeleteAnswerOptionAsync(Guid answerOptionId)
-        {
-            if (answerOptionId == Guid.Empty)
-            {
-                throw new ArgumentException("AnswerOptionId is invalid.", nameof(answerOptionId));
-            }
-            var answerOption = await _unitOfWork.AnswerOptionRepository.GetByIdAsync(answerOptionId);
-            if (answerOption == null)
-            {
-                throw new NotExistException("", "Answer option not found.");
-            }
-            _unitOfWork.AnswerOptionRepository.SoftDeleteAsync(answerOption);
-            await _unitOfWork.SaveAsync();
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Message = "Answer option deleted successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> GetAllUserQuizResultsAsync(PaginationParameter paginationParameter)
-        {
-            var pagedUserQuizResults = await _unitOfWork.UserQuizResultRepository.GetAllUserQuizResultsAsync(paginationParameter);
-            var resultData = _mapper.Map<Pagination<UserQuizResultModel>>(pagedUserQuizResults);
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Data = resultData,
-                Message = "User quiz results retrieved successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> GetUserQuizResultByIdAsync(Guid id)
-        {
-            var userQuizResult = await _unitOfWork.UserQuizResultRepository.GetUserQuizResultByIdAsync(id);
-            var resultData = _mapper.Map<UserQuizResultModel>(userQuizResult);
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Data = resultData,
-                Message = "User quiz results retrieved successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> GetUserQuizResultsByUserIdAsync(PaginationParameter paginationParameter)
-        {
-            var userId = _unitOfWork.UsersRepository.GetUserByEmailAsync(_claimsService.GetCurrentUserEmail).Result.Id;
-            var pagedUserQuizResults = await _unitOfWork.UserQuizResultRepository.GetUserQuizResultsByUserIdAsync(userId, paginationParameter);
-            var resultData = _mapper.Map<Pagination<UserQuizResultModel>>(pagedUserQuizResults);
-            return new BaseResultModel
-            {
-                Status = StatusCodes.Status200OK,
-                Data = resultData,
-                Message = "User quiz results retrieved successfully."
-            };
-        }
-
-        public async Task<BaseResultModel> SetActiveQuizAsync(Guid quizId)
-        {
-            if (quizId == Guid.Empty)
-            {
-                throw new ArgumentException("QuizId is invalid.", nameof(quizId));
-            }
+            var existingQuiz = await _unitOfWork.QuizRepository.GetQuizByIdAsync(quizModel.Id);
+            if (existingQuiz == null)
+                throw new NotExistException($"Không tìm thấy bộ câu hỏi với ID: {quizModel.Id}");
             
-            var quiz = await _unitOfWork.QuizRepository.GetByIdAsync(quizId);
-            if (quiz == null)
-            {
-                throw new NotExistException("", "Quiz not found.");
-            }
+            var updatedQuiz = _mapper.Map<Quiz>(quizModel);
             
-            // Deactivate all quizzes first
-            await _unitOfWork.QuizRepository.DeactivateAllQuizzesAsync();
-            
-            // Set the specified quiz as active
-            quiz.Status = CommonsStatus.ACTIVE;
-            _unitOfWork.QuizRepository.UpdateAsync(quiz);
-            await _unitOfWork.SaveAsync();
+            var result = await _unitOfWork.QuizRepository.UpdateQuizAsync(updatedQuiz);
             
             return new BaseResultModel
             {
                 Status = StatusCodes.Status200OK,
-                Message = "Quiz activated successfully."
+                Data = _mapper.Map<QuizModel>(result),
+                Message = "Cập nhật bộ câu hỏi thành công"
             };
         }
+
+        public async Task<BaseResultModel> ActivateQuizAsync(Guid id)
+        {
+            var allQuizzes = await _unitOfWork.QuizRepository.GetAllAsync();
+            foreach (var quiz in allQuizzes)
+            {
+                quiz.Status = CommonsStatus.INACTIVE;
+                _unitOfWork.QuizRepository.UpdateAsync(quiz);
+            }
+            
+            var quizToActivate = await _unitOfWork.QuizRepository.GetQuizByIdAsync(id);
+            if (quizToActivate == null)
+                throw new NotExistException($"Không tìm thấy bộ câu hỏi với ID: {id}");
+            
+            quizToActivate.Status = CommonsStatus.ACTIVE;
+            _unitOfWork.QuizRepository.UpdateAsync(quizToActivate);
+            
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Data = true,
+                Message = "Kích hoạt bộ câu hỏi thành công"
+            };
+        }
+
+        // USER FUNCTIONS
 
         public async Task<BaseResultModel> GetActiveQuizAsync()
         {
             var quiz = await _unitOfWork.QuizRepository.GetActiveQuizAsync();
             if (quiz == null)
-            {
-                return new BaseResultModel
-                {
-                    Status = StatusCodes.Status404NotFound,
-                    Message = "No active quiz found."
-                };
-            }
+                throw new NotExistException("Không có bộ câu hỏi nào đang hoạt động");
             
             return new BaseResultModel
             {
                 Status = StatusCodes.Status200OK,
                 Data = _mapper.Map<QuizModel>(quiz),
-                Message = "Active quiz retrieved successfully."
+                Message = "Lấy bộ câu hỏi đang hoạt động thành công"
             };
+        }
+
+        public async Task<BaseResultModel> SubmitQuizAnswersAsync(CreateQuizAttemptModel quizAttempt)
+        {
+            var quiz = await _unitOfWork.QuizRepository.GetQuizByIdAsync(quizAttempt.QuizId);
+            if (quiz == null)
+                throw new NotExistException($"Không tìm thấy bộ câu hỏi với ID: {quizAttempt.QuizId}");
+
+            var userId = _unitOfWork.UsersRepository.GetUserByEmailAsync(_claimsService.GetCurrentUserEmail).Result.Id;
+            var user = await _unitOfWork.UsersRepository.GetByIdAsync(userId);
+            if (user == null)
+            {
+                throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+            }
+
+            var quizQuestions = quiz.GetQuestions();
+
+            ValidateQuizAnswers(quizAttempt.Answers, quizQuestions);
+
+            var userQuizResult = new UserQuizResult
+            {
+                UserId = userId,
+                QuizId = quiz.Id,
+                TakenAt = CommonUtils.GetCurrentTime(),
+                QuizVersion = quiz.Version
+            };
+            
+            userQuizResult.SetAnswers(quizAttempt.Answers.Select(a => new UserAnswer
+            {
+                QuestionId = a.QuestionId ?? Guid.Empty,
+                AnswerOptionId = a.AnswerOptionId,     
+                AnswerContent = a.AnswerContent
+            }).ToList());
+            
+            // Calculate recommended spending model based on answers
+            userQuizResult.RecommendedModel = await CalculateRecommendedModel(quiz, quizAttempt.Answers);
+            
+            // Save the result
+            var savedResult = await _unitOfWork.UserQuizResultRepository.CreateUserQuizResultAsync(userQuizResult);
+            
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Data = _mapper.Map<UserQuizResultModel>(savedResult),
+                Message = "Nộp câu trả lời thành công"
+            };
+        }
+
+        private void ValidateQuizAnswers(List<UserAnswerModel> answers, List<QuizQuestion> quizQuestions)
+        {
+            if (answers.Count < quizQuestions.Count)
+            {
+                throw new DefaultException($"Phải trả lời tất cả {quizQuestions.Count} câu hỏi, hiện tại chỉ có {answers.Count} câu trả lời");
+            }
+
+            var answeredQuestionIds = new HashSet<Guid>();
+
+            foreach (var answer in answers)
+            {
+                if (!answer.QuestionId.HasValue)
+                    continue;
+
+                var matchingQuestion = quizQuestions.FirstOrDefault(q => q.Id == answer.QuestionId);
+                
+                if (matchingQuestion == null)
+                {
+                    throw new DefaultException($"Câu hỏi với ID {answer.QuestionId} không tồn tại trong bộ câu hỏi");
+                }
+
+                if (answer.AnswerOptionId.HasValue)
+                {
+                    var matchingOption = matchingQuestion.AnswerOptions.FirstOrDefault(o => o.Id == answer.AnswerOptionId);
+                    if (matchingOption == null)
+                    {
+                        throw new DefaultException($"Lựa chọn với ID {answer.AnswerOptionId} không tồn tại trong câu hỏi {matchingQuestion.Content}");
+                    }
+                }
+                
+                answeredQuestionIds.Add(matchingQuestion.Id);
+            }
+
+            var unansweredQuestions = quizQuestions.Where(q => !answeredQuestionIds.Contains(q.Id)).ToList();
+            if (unansweredQuestions.Any())
+            {
+                var missingQuestions = string.Join(", ", unansweredQuestions.Select(q => q.Content));
+                throw new DefaultException($"Thiếu câu trả lời cho các câu hỏi sau: {missingQuestions}");
+            }
+
+            // Ensure all answers have content
+            var emptyAnswers = answers.Where(a => string.IsNullOrWhiteSpace(a.AnswerContent)).ToList();
+            if (emptyAnswers.Any())
+            {
+                throw new DefaultException("Tất cả các câu trả lời phải có nội dung");
+            }
+        }
+
+        public async Task<BaseResultModel> GetUserQuizHistoryAsync(PaginationParameter paginationParameter)
+        {
+            var userId = _unitOfWork.UsersRepository.GetUserByEmailAsync(_claimsService.GetCurrentUserEmail).Result.Id;
+            var user = await _unitOfWork.UsersRepository.GetByIdAsync(userId);
+            if (user == null)
+            {
+                throw new NotExistException(MessageConstants.ACCOUNT_NOT_EXIST);
+            }
+
+            var userQuizResultsPagination = await _unitOfWork.UserQuizResultRepository.GetUserQuizResultsByUserIdPaginatedAsync(userId, paginationParameter);
+            var userQuizResultModels = _mapper.Map<List<UserQuizResultModel>>(userQuizResultsPagination);
+            
+            return new BaseResultModel
+            {
+                Status = StatusCodes.Status200OK,
+                Data = PaginationHelper.GetPaginationResult(userQuizResultsPagination, userQuizResultModels),
+                Message = "Lấy lịch sử làm bài thành công"
+            };
+        }
+
+        private async Task<string> CalculateRecommendedModel(Quiz quiz, List<UserAnswerModel> answers)
+        {
+            return "50-30-20"; 
         }
     }
 }

--- a/MoneyEz.Services/Services/Interfaces/IQuizService.cs
+++ b/MoneyEz.Services/Services/Interfaces/IQuizService.cs
@@ -1,31 +1,24 @@
 ﻿using MoneyEz.Repositories.Commons;
-using MoneyEz.Repositories.Entities;
-using MoneyEz.Services.BusinessModels.ChatModels;
 using MoneyEz.Services.BusinessModels.QuizModels;
 using MoneyEz.Services.BusinessModels.ResultModels;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MoneyEz.Services.Services.Interfaces
 {
     public interface IQuizService
     {
+        // Admin functions
         Task<BaseResultModel> CreateQuizAsync(CreateQuizModel createQuizModel);
-        Task<BaseResultModel> SubmitQuizAttemptAsync(CreateQuizAttemptModel quizAttemptModel);
-        Task<BaseResultModel> GetQuizByIdAsync(Guid quizId);
-        Task<BaseResultModel> GetQuizListAsync(PaginationParameter paginationParameter);
-        Task<BaseResultModel> UpdateQuizAsync(QuizModel quizModel);
-        Task<BaseResultModel> DeleteQuizAsync(Guid quizId);
-        Task<BaseResultModel> GetQuestionsByQuizIdAsync(Guid quizId);
-        Task<BaseResultModel> CreateQuestionAsync(Guid quizId, CreateQuestionModel questionModel);
-        Task<BaseResultModel> UpdateQuestionAsync(QuestionModel questionModel);
-        Task<BaseResultModel> DeleteQuestionAsync(Guid questionId);
-        Task<BaseResultModel> CreateAnswerOptionAsync(Guid questionId, CreateAnswerOptionModel answerOptionModel);
-        Task<BaseResultModel> UpdateAnswerOptionAsync(AnswerOptionModel answerOptionModel);
-        Task<BaseResultModel> DeleteAnswerOptionAsync(Guid answerOptionId);
-        Task<BaseResultModel> GetAllUserQuizResultsAsync(PaginationParameter paginationParameter);
-        Task<BaseResultModel> GetUserQuizResultByIdAsync(Guid id);
-        Task<BaseResultModel> GetUserQuizResultsByUserIdAsync(PaginationParameter paginationParameter);
+        Task<BaseResultModel> GetQuizByIdAsync(Guid id);
+        Task<BaseResultModel> GetAllQuizzesAsync(PaginationParameter paginationParameter);
+        Task<BaseResultModel> UpdateQuizAsync(UpdateQuizModel quizModel);
+        Task<BaseResultModel> ActivateQuizAsync(Guid id);
         
-        Task<BaseResultModel> SetActiveQuizAsync(Guid quizId);
+        // User functions
         Task<BaseResultModel> GetActiveQuizAsync();
+        Task<BaseResultModel> SubmitQuizAnswersAsync(CreateQuizAttemptModel quizAttempt);
+        Task<BaseResultModel> GetUserQuizHistoryAsync(PaginationParameter paginationParameter);
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the `QuizController` and the database schema for quizzes, questions, and answers. The main goal is to refactor the quiz-related entities and endpoints to use a NoSQL-style JSON storage approach for questions and answers.

### Controller changes:

* [`MoneyEz.API/Controllers/QuizController.cs`](diffhunk://#diff-429ba101678bb3019ae4962198e0f0164817f4db6cad1b2e9573e0ff9712dd66L26-R26): Updated various methods to use new service methods and improved authorization. For example, `GetAllQuizzes` now calls `GetAllQuizzesAsync`, and `SubmitQuizAttempt` now calls `SubmitQuizAnswersAsync`. [[1]](diffhunk://#diff-429ba101678bb3019ae4962198e0f0164817f4db6cad1b2e9573e0ff9712dd66L26-R26) [[2]](diffhunk://#diff-429ba101678bb3019ae4962198e0f0164817f4db6cad1b2e9573e0ff9712dd66L39-R39) [[3]](diffhunk://#diff-429ba101678bb3019ae4962198e0f0164817f4db6cad1b2e9573e0ff9712dd66L54-R64) [[4]](diffhunk://#diff-429ba101678bb3019ae4962198e0f0164817f4db6cad1b2e9573e0ff9712dd66L148-R76) [[5]](diffhunk://#diff-429ba101678bb3019ae4962198e0f0164817f4db6cad1b2e9573e0ff9712dd66L160-R88)

### Database schema changes:

* [`MoneyEz.Repositories/Entities/MoneyEzContext.cs`](diffhunk://#diff-0795c5c0d12ecbc3a9bd459f69780294fd60fb2145c858d55a357b193ece6baeL65-L70): Removed `AnswerOption`, `Question`, and `UserQuizAnswer` DbSets and their related configurations. Added new properties `QuestionsJson` and `Version` to the `Quiz` entity, and `QuizVersion` and `AnswersJson` to the `UserQuizResult` entity. [[1]](diffhunk://#diff-0795c5c0d12ecbc3a9bd459f69780294fd60fb2145c858d55a357b193ece6baeL65-L70) [[2]](diffhunk://#diff-0795c5c0d12ecbc3a9bd459f69780294fd60fb2145c858d55a357b193ece6baeL573-R569) [[3]](diffhunk://#diff-0795c5c0d12ecbc3a9bd459f69780294fd60fb2145c858d55a357b193ece6baeR581-R582) [[4]](diffhunk://#diff-0795c5c0d12ecbc3a9bd459f69780294fd60fb2145c858d55a357b193ece6baeL624-L641)

* [`MoneyEz.Repositories/Entities/Quiz.cs`](diffhunk://#diff-819ec7682955489107c32d1305de82c7d70c721886cc63b471e1018d9d7ac3a2R5): Added properties to store questions and answers as JSON strings, along with helper methods for serialization and deserialization. [[1]](diffhunk://#diff-819ec7682955489107c32d1305de82c7d70c721886cc63b471e1018d9d7ac3a2R5) [[2]](diffhunk://#diff-819ec7682955489107c32d1305de82c7d70c721886cc63b471e1018d9d7ac3a2L16-R49)

* [`MoneyEz.Repositories/Entities/UserQuizResult.cs`](diffhunk://#diff-4a85bf4ec5f466c5567895634cc32a0f27331a3e03054dd73f14e29a3492e35dR4): Added properties for storing quiz version and answers as JSON strings, with helper methods for serialization and deserialization. [[1]](diffhunk://#diff-4a85bf4ec5f466c5567895634cc32a0f27331a3e03054dd73f14e29a3492e35dR4) [[2]](diffhunk://#diff-4a85bf4ec5f466c5567895634cc32a0f27331a3e03054dd73f14e29a3492e35dR18-R47)

### Migration:

* [`MoneyEz.Repositories/Migrations/20250331204042_UpdateQuizIntoNoSQLStyle.cs`](diffhunk://#diff-bb099f836f5ae1d679814f9f0dde7a1d3098208699a86e0fbfe9c6505796ac14R1-R295): Created a migration to update the database schema to the new NoSQL-style storage for quizzes and user quiz results. This includes adding new columns and removing foreign key constraints and primary keys related to the old question and answer entities.